### PR TITLE
Fixed #50 for reals

### DIFF
--- a/app/src/main/java/com/simplemobiletools/gallery/Utils.kt
+++ b/app/src/main/java/com/simplemobiletools/gallery/Utils.kt
@@ -171,7 +171,9 @@ class Utils {
         }
 
         fun isShowingWritePermissions(activity: Activity, file: File): Boolean {
-            return if (needsStupidWritePermissions(activity, file.absolutePath) && !file.canWrite() && Config.newInstance(activity).treeUri.isEmpty()) {
+            return if ((needsStupidWritePermissions(activity, file.absolutePath) &&
+                        !file.canWrite()) ||
+                        Config.newInstance(activity).treeUri.isEmpty()) {
                 WritePermissionDialog(activity, object : WritePermissionDialog.OnWritePermissionListener {
                     override fun onConfirmed() {
                         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)


### PR DESCRIPTION
`treeUri` needs to be set at least once, always (despite we already have write access or not).