### PR TITLE
Update zh-rTW translation: fix "gallery" translation

### DIFF
--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,8 +1,8 @@
 <resources>
-    <string name="app_name">簡易相簿</string>
-    <string name="app_launcher_name">相簿</string>
+    <string name="app_name">簡易藝廊</string>
+    <string name="app_launcher_name">藝廊</string>
     <string name="share_via">分享到</string>
-    <string name="no_permissions">一個沒有權限存取您的儲存空間的相簿能做的事情寥寥無幾</string>
+    <string name="no_permissions">一個沒有權限存取您的儲存空間的藝廊能做的事情寥寥無幾</string>
     <string name="deleting">正在刪除</string>
     <string name="edit">編輯</string>
     <string name="undo">復原</string>
@@ -96,12 +96,12 @@
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- Short description has to have less than 80 chars -->
-    <string name="app_short_description">一個沒有廣告，用來觀看照片及影片的相簿。.</string>
+    <string name="app_short_description">一個沒有廣告，用來觀看照片及影片的藝廊。.</string>
     <string name="app_long_description">
         一個觀看照片跟影片的簡單實用工具。項目可以根據日期、大小、名稱來進行遞增及遞減排序，照片可以縮放。媒體檔案們根據螢幕的大小呈列在多個方格中，您可以使用捏放手勢來調整一列中的方格數量。媒體檔案可以被重新命名、分享、刪除、複製以及移動。照片亦可被裁切、旋轉或是直接在應用軟體中設定為桌布。
 
 
-        相簿亦提供讓第三方軟體能夠用來預覽圖片／影片、添加附件於電子郵件客戶端軟體中等。非常適合日常使用。
+        藝廊亦提供讓第三方軟體能夠用來預覽圖片／影片、添加附件於電子郵件客戶端軟體中等。非常適合日常使用。
 
         應用軟體不包含廣告與非必要的權限。它是完全開放軟體來源碼的，並內建一個暗色使用者介面主題。
 


### PR DESCRIPTION
Previously I use "相簿" a.k.a. "相本"(in zh-rCN) a.k.a. "Album" in English,
but after discussion with L10N-TW community "藝廊" a.k.a. "gallery" should
be a much precise and sane translation.

Reference:

* Search result:
<https://duckduckgo.com/?q=藝廊&ia=images&iai=http%3A%2F%2Fwww.akigallery.com.tw%2Fimages%2Faboutus_03_2.jpg>
* Chinese Dictionary of Ministry of Education, TW:
<https://www.moedict.tw/藝廊>

Signed-off-by: Ｖ字龍 &lt;<Vdragon.Taiwan@gmail.com>&gt;