### PR TITLE
Use subsamplingScaleImageView for PNGs

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/fragments/PhotoFragment.kt
@@ -186,7 +186,7 @@ class PhotoFragment : ViewPagerFragment() {
     }
 
     private fun addZoomableView() {
-        if (medium.isJpg() && isMenuVisible && view.subsampling_view.visibility == View.GONE) {
+        if ((medium.isJpg() || medium.isPng()) && isMenuVisible && view.subsampling_view.visibility == View.GONE) {
             view.subsampling_view.apply {
                 beVisible()
                 setDoubleTapZoomScale(1.4f)


### PR DESCRIPTION
This should fix #144. I'm not entirely sure what the issue mentioned in that thread was with rendering PNGs as ARGB_8888. I tried several PNGs both with and without alpha channels, and they rendered perfectly. Is it a matter of performance? If it is, I haven't noticed a drop in performance when viewing PNGs with this patch.