### PR TITLE
Resources.getActionBarHeight() fix return style

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/extensions/Resources.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/extensions/Resources.kt
@@ -6,11 +6,10 @@ import android.util.TypedValue
 
 fun Resources.getActionBarHeight(context: Context): Int {
     val tv = TypedValue()
-    var height = 0
-    if (context.theme.resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
-        height = TypedValue.complexToDimensionPixelSize(tv.data, displayMetrics)
-    }
-    return height
+    return if (context.theme.resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+        TypedValue.complexToDimensionPixelSize(tv.data, displayMetrics)
+    } else
+        0
 }
 
 fun Resources.getStatusBarHeight(): Int {


### PR DESCRIPTION
Uses the same return style as in the other functions