### PR TITLE
fixed bug where app will close if all media is missing or excluded

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/activities/MediaActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/activities/MediaActivity.kt
@@ -262,7 +262,7 @@ class MediaActivity : SimpleActivity(), MediaAdapter.MediaOperationsListener {
     }
 
     private fun setupAdapter() {
-        if (isDirEmpty()) {
+        if (!mShowAll && isDirEmpty()) {
             return
         }
 


### PR DESCRIPTION
This is a fix for #578 and possibly #574 
I am not sure of the context/repro for #574 