### PR TITLE
Dutch + 2 remarks

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -133,13 +133,13 @@
     <string name="manage_extended_details">Uitgebreide informatie</string>
     <string name="one_finger_zoom">Met één vinger zoomen in volledig scherm</string>
     <string name="allow_instant_change">Direct naar vorige/volgende door op de zijkanten van het scherm te tikken</string>
-    <string name="replace_zoomable_images">Replace deep zoomable images with better quality ones</string>
-    <string name="hide_extended_details">Hide extended details when status bar is hidden</string>
+    <string name="replace_zoomable_images">Betere kwaliteit hanteren bij ver inzoomen</string>
+    <string name="hide_extended_details">Uitgebreide informatie niet tonen als de statusbalk is verborgen</string>
 
     <!-- Setting sections -->
     <string name="thumbnails">Miniatuurvoorbeelden</string>
     <string name="fullscreen_media">Volledig scherm</string>
-    <string name="extended_details">Extended details</string>
+    <string name="extended_details">Uitgebreide informatie</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- Short description has to have less than 80 chars -->


### PR DESCRIPTION
1. When "Replace zoomable images" is enabled, I can actually zoom less than when it's disabled
2. One finger zoom somehow puts the image upside down after some zooming in and out. Perhaps EXIF-tag or "rotate according to device orientation" related?

(Not the right place, I know)