### PR TITLE
Translate missing strings in german

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,9 +25,9 @@
     <string name="lock_orientation">Bildschirmausrichtung sperren</string>
     <string name="unlock_orientation">Bildschirmausrichtung entsperren</string>
     <string name="change_orientation">Change orientation</string>
-    <string name="force_portrait">Force portrait</string>
-    <string name="force_landscape">Force landscape</string>
-    <string name="use_default_orientation">Use default orientation</string>
+    <string name="force_portrait">Hochkant erzwingen</string>
+    <string name="force_landscape">Breitbild erzwingen</string>
+    <string name="use_default_orientation">Standard Ausrichtung benutzen</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter</string>


### PR DESCRIPTION
Translated:
```
force_portrait
force_landscape
use_default_orientation
```

I'm new to simple mobile tools and don't yet know what words best fit the expectation/experience, so let me know if any german speaker has suggestions or of cause I wont cry if someone else sees a better fit ;-)