### PR TITLE
Loop videos without gaps between playback

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/VideoPlayerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/VideoPlayerActivity.kt
@@ -347,13 +347,9 @@ open class VideoPlayerActivity : SimpleActivity(), SeekBar.OnSeekBarChangeListen
 
         clearLastVideoSavedProgress()
         mCurrTime = (mExoPlayer!!.duration / 1000).toInt()
-        if (config.loopVideos) {
-            resumeVideo()
-        } else {
-            video_seekbar.progress = video_seekbar.max
-            video_curr_time.text = mDuration.getFormattedDuration()
-            pauseVideo()
-        }
+        video_seekbar.progress = video_seekbar.max
+        video_curr_time.text = mDuration.getFormattedDuration()
+        pauseVideo()
     }
 
     private fun didVideoEnd(): Boolean {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/VideoPlayerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/VideoPlayerActivity.kt
@@ -234,7 +234,13 @@ open class VideoPlayerActivity : SimpleActivity(), SeekBar.OnSeekBarChangeListen
 
             override fun onLoadingChanged(isLoading: Boolean) {}
 
-            override fun onPositionDiscontinuity(reason: Int) {}
+            override fun onPositionDiscontinuity(reason: Int) {
+                // Reset progress views when video loops.
+                if (reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
+                    video_seekbar.progress = 0
+                    video_curr_time.text = 0.getFormattedDuration()
+                }
+            }
 
             override fun onRepeatModeChanged(repeatMode: Int) {}
 

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/VideoPlayerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/VideoPlayerActivity.kt
@@ -214,6 +214,9 @@ open class VideoPlayerActivity : SimpleActivity(), SeekBar.OnSeekBarChangeListen
         mExoPlayer = ExoPlayerFactory.newSimpleInstance(applicationContext).apply {
             seekParameters = SeekParameters.CLOSEST_SYNC
             audioStreamType = C.STREAM_TYPE_MUSIC
+            if (config.loopVideos) {
+                repeatMode = Player.REPEAT_MODE_ONE
+            }
             prepare(audioSource)
         }
         initExoPlayerListeners()

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
@@ -681,13 +681,9 @@ class VideoFragment : ViewPagerFragment(), TextureView.SurfaceTextureListener, S
         }
 
         mCurrTime = (mExoPlayer!!.duration / 1000).toInt()
-        if (listener?.videoEnded() == false && mConfig.loopVideos) {
-            playVideo()
-        } else {
-            mSeekBar.progress = mSeekBar.max
-            mCurrTimeView.text = mDuration.getFormattedDuration()
-            pauseVideo()
-        }
+        mSeekBar.progress = mSeekBar.max
+        mCurrTimeView.text = mDuration.getFormattedDuration()
+        pauseVideo()
     }
 
     private fun cleanup() {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
@@ -353,7 +353,13 @@ class VideoFragment : ViewPagerFragment(), TextureView.SurfaceTextureListener, S
 
             override fun onLoadingChanged(isLoading: Boolean) {}
 
-            override fun onPositionDiscontinuity(reason: Int) {}
+            override fun onPositionDiscontinuity(reason: Int) {
+                // Reset progress views when video loops.
+                if (reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
+                    mSeekBar.progress = 0
+                    mCurrTimeView.text = 0.getFormattedDuration()
+                }
+            }
 
             override fun onRepeatModeChanged(repeatMode: Int) {}
 

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
@@ -317,6 +317,9 @@ class VideoFragment : ViewPagerFragment(), TextureView.SurfaceTextureListener, S
 
         mExoPlayer = ExoPlayerFactory.newSimpleInstance(context)
         mExoPlayer!!.seekParameters = SeekParameters.CLOSEST_SYNC
+        if (mConfig.loopVideos) {
+            mExoPlayer?.repeatMode = Player.REPEAT_MODE_ONE
+        }
 
         val isContentUri = mMedium.path.startsWith("content://")
         val uri = if (isContentUri) Uri.parse(mMedium.path) else Uri.fromFile(File(mMedium.path))


### PR DESCRIPTION
As GIFs continue to be replaced by videos, it becomes increasingly important to support gapless video loops.
ExoPlayer 2.5 brought upstream support for seamless video looping functionality through prebuffering. This behaviour is preferable to the current implementation, which seeks to the start of the video and has a noticeable, if minor, delay.

Note: a minor downside of using ExoPlayer's implementation is that certain broken videos which previously played in Simple Gallery will no longer start, due to an as-of-yet unfixed bug (google/ExoPlayer#6459). Such videos have an audio track of only a few samples (less than a fifth of a second), and playback could be re-enabled by disabling video loops (and falling back on the seek method) or disabling the audio track itself. However, ExoPlayer unfortunately does not provide any way to check the duration of the audio track in order to do this automatically, so there is no workaround. I figure that this shouldn't be a deal-breaker, since broken videos aren't expected to be supported to begin with.