### PR TITLE
Not to refresh and show all media even query text is not empty.

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MediaActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MediaActivity.kt
@@ -60,6 +60,7 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
     private var mShowAll = false
     private var mLoadedInitialPhotos = false
     private var mIsSearchOpen = false
+    private var mLastSearchedText = ""
     private var mLatestMediaId = 0L
     private var mLatestMediaDateId = 0L
     private var mLastMediaHandler = Handler()
@@ -301,6 +302,7 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
 
                 override fun onQueryTextChange(newText: String): Boolean {
                     if (mIsSearchOpen) {
+                        mLastSearchedText = newText
                         searchQueryChanged(newText)
                     }
                     return true
@@ -319,6 +321,8 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
             override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
                 if (mIsSearchOpen) {
                     mIsSearchOpen = false
+                    mLastSearchedText = ""
+
                     media_refresh_layout.isEnabled = config.enablePullToRefresh
                     searchQueryChanged("")
                 }
@@ -389,11 +393,14 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
                 media_grid.adapter = this
             }
             setupLayoutManager()
-        } else {
+            measureRecyclerViewContent(mMedia)
+        } else if (mLastSearchedText.isEmpty()) {
             (currAdapter as MediaAdapter).updateMedia(mMedia)
+            measureRecyclerViewContent(mMedia)
+        } else {
+            searchQueryChanged(mLastSearchedText)
         }
 
-        measureRecyclerViewContent(mMedia)
         setupScrollDirection()
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SearchActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SearchActivity.kt
@@ -134,11 +134,14 @@ class SearchActivity : SimpleActivity(), MediaOperationsListener {
                 media_grid.adapter = this
             }
             setupLayoutManager()
-        } else {
+            measureRecyclerViewContent(mAllMedia)
+        } else if (mLastSearchedText.isEmpty()) {
             (currAdapter as MediaAdapter).updateMedia(mAllMedia)
+            measureRecyclerViewContent(mAllMedia)
+        } else {
+            textChanged(mLastSearchedText)
         }
 
-        measureRecyclerViewContent(mAllMedia)
         setupScrollDirection()
     }
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -292,7 +292,7 @@
     <string name="faq_3_title">Hoe kan ik een map bovenaan vastzetten?</string>
     <string name="faq_3_text">Druk lang op het map en kies vervolgens de punaise in het actiemenu. Als er meerdere mappen zijn vastgezet, zullen deze worden weergeven op basis van de standaardsortering.</string>
     <string name="faq_4_title">Hoe kan ik terug- of vooruitspoelen in video’s?</string>
-    <string name="faq_4_text">Dubbelklik op de zijkant van het scherm, of tik op de cijfers die de voortgang of de lengte van de video weergeven om resp. terug of vooruit te springen. Als de instelling om video's in een apart scherm te openen is ingeschakeld, dan kunnen ook horizontale veeggebaren worden gebruikt.</string>
+    <string name="faq_4_text">Dubbelklik op de zijkant van het scherm, of tik op de cijfers die de voortgang of de lengte van de video weergeven om resp. terug of vooruit te springen. Als de instelling om video\'s in een apart scherm te openen is ingeschakeld, dan kunnen ook horizontale veeggebaren worden gebruikt.</string>
     <string name="faq_5_title">Wat is het verschil tussen het verbergen en het uitsluiten van mappen?</string>
     <string name="faq_5_text">Met \"Uitsluiten\" wordt het tonen van de map alleen binnen deze app voorkomen, terwijl \"Verbergen\" de map ook zal verbergen voor andere galerij-apps. Met \"Verbergen\" wordt een bestand genaamd \".nomedia\" in de te verbergen map aangemaakt (het verwijderen van dit bestand uit de map maakt het verbergen ongedaan).</string>
     <string name="faq_6_title">Waarom zie ik mappen met stickers of covers van muziekalbums?</string>


### PR DESCRIPTION
It's very uncomfortable when I search image in directory that contains over 2,000 images. MediaActivity shows all images even though query text is not empty about 1~2 seconds after onCreate called. Please consider merge this PR.