### PR TITLE
Features/exif copy

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/EditActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/EditActivity.kt
@@ -39,6 +39,7 @@ import com.simplemobiletools.gallery.pro.dialogs.OtherAspectRatioDialog
 import com.simplemobiletools.gallery.pro.dialogs.ResizeDialog
 import com.simplemobiletools.gallery.pro.dialogs.SaveAsDialog
 import com.simplemobiletools.gallery.pro.extensions.config
+import com.simplemobiletools.gallery.pro.extensions.copyNonDimensionAttributesTo
 import com.simplemobiletools.gallery.pro.extensions.fixDateTaken
 import com.simplemobiletools.gallery.pro.extensions.openEditor
 import com.simplemobiletools.gallery.pro.helpers.*
@@ -869,7 +870,7 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
         try {
             if (isNougatPlus()) {
                 val newExif = ExifInterface(file.absolutePath)
-                oldExif?.copyTo(newExif, false)
+                oldExif?.copyNonDimensionAttributesTo(newExif)
             }
         } catch (e: Exception) {
         }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/EditActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/EditActivity.kt
@@ -304,16 +304,7 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
 
     @TargetApi(Build.VERSION_CODES.N)
     private fun saveImage() {
-        var inputStream: InputStream? = null
-        try {
-            if (isNougatPlus()) {
-                inputStream = contentResolver.openInputStream(uri!!)
-                oldExif = ExifInterface(inputStream!!)
-            }
-        } catch (e: Exception) {
-        } finally {
-            inputStream?.close()
-        }
+        setOldExif()
 
         if (crop_image_view.isVisible()) {
             crop_image_view.getCroppedImageAsync()
@@ -351,6 +342,20 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
                     }
                 }
             }
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    private fun setOldExif() {
+        var inputStream: InputStream? = null
+        try {
+            if (isNougatPlus()) {
+                inputStream = contentResolver.openInputStream(uri!!)
+                oldExif = ExifInterface(inputStream!!)
+            }
+        } catch (e: Exception) {
+        } finally {
+            inputStream?.close()
         }
     }
 
@@ -742,6 +747,8 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
 
     override fun onCropImageComplete(view: CropImageView, result: CropImageView.CropResult) {
         if (result.error == null) {
+            setOldExif()
+
             val bitmap = result.bitmap
             if (isSharingBitmap) {
                 isSharingBitmap = false

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -986,7 +986,7 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
 
             if (isNougatPlus()) {
                 val newExif = ExifInterface(file.absolutePath)
-                oldExif?.copyTo(newExif, false)
+                oldExif?.copyNonDimensionAttributesTo(newExif)
             }
         } catch (e: Exception) {
         }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/ExifInterface.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/ExifInterface.kt
@@ -1,0 +1,57 @@
+package com.simplemobiletools.gallery.pro.extensions
+
+import android.media.ExifInterface
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+
+fun ExifInterface.copyNonDimensionAttributesTo(destination: ExifInterface) {
+    val attributes = ExifInterfaceAttributes.AllNonDimensionAttributes
+
+    attributes.forEach {
+        val value = getAttribute(it)
+        if (value != null) {
+            destination.setAttribute(it, value)
+        }
+    }
+
+    try {
+        destination.saveAttributes()
+    } catch (ignored: Exception) {
+    }
+}
+
+private class ExifInterfaceAttributes {
+    companion object {
+        val AllNonDimensionAttributes = getAllNonDimensionExifAttributes()
+
+        private fun getAllNonDimensionExifAttributes(): List<String> {
+            val tagFields = ExifInterface::class.java.fields.filter { field -> isExif(field) }
+
+            val excludeAttributes = arrayListOf(
+                    ExifInterface.TAG_IMAGE_LENGTH,
+                    ExifInterface.TAG_IMAGE_WIDTH,
+                    ExifInterface.TAG_PIXEL_X_DIMENSION,
+                    ExifInterface.TAG_PIXEL_Y_DIMENSION,
+                    ExifInterface.TAG_THUMBNAIL_IMAGE_LENGTH,
+                    ExifInterface.TAG_THUMBNAIL_IMAGE_WIDTH,
+                    ExifInterface.TAG_ORIENTATION)
+
+            return tagFields
+                    .map { tagField -> tagField.get(null) as String }
+                    .filter { x -> !excludeAttributes.contains(x) }
+                    .distinct()
+        }
+
+        private fun isExif(field: Field): Boolean {
+            return field.type == String::class.java &&
+                    isPublicStaticFinal(field.modifiers) &&
+                    field.name.startsWith("TAG_")
+        }
+
+        private const val publicStaticFinal = Modifier.PUBLIC or Modifier.STATIC or Modifier.FINAL
+
+        private fun isPublicStaticFinal(modifiers: Int): Boolean {
+            return modifiers and publicStaticFinal > 0
+        }
+    }
+}


### PR DESCRIPTION
The first commit is to set missing old EXIF to be copied when image is resized in the editor.

The second commit is to copy all EXIF attributes, except a few selected, rather than only selected ones. Done this in the same Gallery project rather than Commons - would leave it up to you if you would want it in the Commons.