### PR TITLE
Remove multidex library.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,6 @@ android {
         targetSdkVersion 29
         versionCode 314
         versionName "6.15.2"
-        multiDexEnabled true
         setProperty("archivesBaseName", "gallery-$versionCode")
         vectorDrawables.useSupportLibrary = true
     }
@@ -80,7 +79,6 @@ android {
 dependencies {
     implementation 'com.simplemobiletools:commons:5.29.20'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
-    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'it.sephiroth.android.exif:library:1.0.1'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.19'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta7'

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/App.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/App.kt
@@ -1,10 +1,10 @@
 package com.simplemobiletools.gallery.pro
 
-import androidx.multidex.MultiDexApplication
+import android.app.Application
 import com.github.ajalt.reprint.core.Reprint
 import com.simplemobiletools.commons.extensions.checkUseEnglish
 
-class App : MultiDexApplication() {
+class App : Application() {
     override fun onCreate() {
         super.onCreate()
         checkUseEnglish()


### PR DESCRIPTION
Remove the multidex library, as Android Lollipop and higher natively support multiple DEX files.