### PR TITLE
Use ShortcutManagerCompat.

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -7,14 +7,11 @@ import android.annotation.TargetApi
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ActivityInfo
-import android.content.pm.ShortcutInfo
-import android.content.pm.ShortcutManager
 import android.content.res.Configuration
 import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.graphics.drawable.Icon
 import android.media.ExifInterface
 import android.net.Uri
 import android.os.Build
@@ -28,6 +25,8 @@ import android.view.View
 import android.view.WindowManager
 import android.view.animation.DecelerateInterpolator
 import android.widget.Toast
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.print.PrintHelper
 import androidx.viewpager.widget.ViewPager
 import com.bumptech.glide.Glide
@@ -700,10 +699,8 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
         }
     }
 
-    @SuppressLint("NewApi")
     private fun createShortcut() {
-        val manager = getSystemService(ShortcutManager::class.java)
-        if (manager.isRequestPinShortcutSupported) {
+        if (isRequestPinShortcutSupported) {
             val medium = getCurrentMedium() ?: return
             val path = medium.path
             val drawable = resources.getDrawable(R.drawable.shortcut_image).mutate()
@@ -717,13 +714,13 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
                     flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
 
-                val shortcut = ShortcutInfo.Builder(this, path)
+                val shortcut = ShortcutInfoCompat.Builder(this, path)
                     .setShortLabel(medium.name)
-                    .setIcon(Icon.createWithBitmap(drawable.convertToBitmap()))
+                    .setIcon(IconCompat.createWithBitmap(drawable.convertToBitmap()))
                     .setIntent(intent)
                     .build()
 
-                manager.requestPinShortcut(shortcut, null)
+                requestPinShortcut(shortcut)
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
@@ -1,14 +1,12 @@
 package com.simplemobiletools.gallery.pro.adapters
 
-import android.annotation.SuppressLint
 import android.content.Intent
-import android.content.pm.ShortcutInfo
-import android.content.pm.ShortcutManager
 import android.graphics.drawable.ColorDrawable
-import android.graphics.drawable.Icon
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.bumptech.glide.Glide
 import com.google.gson.Gson
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
@@ -463,10 +461,8 @@ class DirectoryAdapter(activity: BaseSimpleActivity, var dirs: ArrayList<Directo
         }
     }
 
-    @SuppressLint("NewApi")
     private fun createShortcut() {
-        val manager = activity.getSystemService(ShortcutManager::class.java)
-        if (manager.isRequestPinShortcutSupported) {
+        if (activity.isRequestPinShortcutSupported) {
             val dir = getFirstSelectedItem() ?: return
             val path = dir.path
             val drawable = resources.getDrawable(R.drawable.shortcut_image).mutate()
@@ -477,13 +473,13 @@ class DirectoryAdapter(activity: BaseSimpleActivity, var dirs: ArrayList<Directo
                 intent.flags = intent.flags or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 intent.putExtra(DIRECTORY, path)
 
-                val shortcut = ShortcutInfo.Builder(activity, path)
+                val shortcut = ShortcutInfoCompat.Builder(activity, path)
                         .setShortLabel(dir.name)
-                        .setIcon(Icon.createWithBitmap(drawable.convertToBitmap()))
+                        .setIcon(IconCompat.createWithBitmap(drawable.convertToBitmap()))
                         .setIntent(intent)
                         .build()
 
-                manager.requestPinShortcut(shortcut, null)
+                activity.requestPinShortcut(shortcut)
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
@@ -1,16 +1,14 @@
 package com.simplemobiletools.gallery.pro.adapters
 
-import android.annotation.SuppressLint
 import android.content.Intent
-import android.content.pm.ShortcutInfo
-import android.content.pm.ShortcutManager
-import android.graphics.drawable.Icon
 import android.os.Handler
 import android.os.Looper
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.bumptech.glide.Glide
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.adapters.MyRecyclerViewAdapter
@@ -352,10 +350,8 @@ class MediaAdapter(activity: BaseSimpleActivity, var media: MutableList<Thumbnai
         }
     }
 
-    @SuppressLint("NewApi")
     private fun createShortcut() {
-        val manager = activity.getSystemService(ShortcutManager::class.java)
-        if (manager.isRequestPinShortcutSupported) {
+        if (activity.isRequestPinShortcutSupported) {
             val path = getSelectedPaths().first()
             val drawable = resources.getDrawable(R.drawable.shortcut_image).mutate()
             activity.getShortcutImage(path, drawable) {
@@ -368,13 +364,13 @@ class MediaAdapter(activity: BaseSimpleActivity, var media: MutableList<Thumbnai
                     flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
 
-                val shortcut = ShortcutInfo.Builder(activity, path)
+                val shortcut = ShortcutInfoCompat.Builder(activity, path)
                         .setShortLabel(path.getFilenameFromPath())
-                        .setIcon(Icon.createWithBitmap(drawable.convertToBitmap()))
+                        .setIcon(IconCompat.createWithBitmap(drawable.convertToBitmap()))
                         .setIntent(intent)
                         .build()
 
-                manager.requestPinShortcut(shortcut, null)
+                activity.requestPinShortcut(shortcut)
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Context.kt
@@ -4,12 +4,15 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.IntentSender
 import android.database.Cursor
 import android.graphics.drawable.PictureDrawable
 import android.media.AudioManager
 import android.provider.MediaStore.Files
 import android.provider.MediaStore.Images
 import android.widget.ImageView
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DecodeFormat
@@ -907,3 +910,12 @@ fun Context.getFileDateTaken(path: String): Long {
 
     return 0L
 }
+
+inline val Context.isRequestPinShortcutSupported
+    get() = ShortcutManagerCompat.isRequestPinShortcutSupported(this)
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun Context.requestPinShortcut(
+        shortcut: ShortcutInfoCompat,
+        callback: IntentSender? = null
+) = ShortcutManagerCompat.requestPinShortcut(this, shortcut, callback)


### PR DESCRIPTION
Use [`ShortcutManagerCompat`](https://developer.android.com/reference/androidx/core/content/pm/ShortcutManagerCompat)'s `isRequestPinShortcutSupported()` and `requestPinShortcut()` methods to create shortcuts even on API levels below 25.