### PR TITLE
Use suspend functions in DirectoryDao.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,11 @@ android {
     }
 }
 
+ext {
+    coroutines_version = '1.3.9'
+    room_version = '2.2.5'
+}
+
 dependencies {
     implementation 'com.simplemobiletools:commons:5.30.17'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
@@ -96,9 +101,14 @@ dependencies {
 
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
-    kapt 'androidx.room:room-compiler:2.2.5'
-    implementation 'androidx.room:room-runtime:2.2.5'
-    annotationProcessor 'androidx.room:room-compiler:2.2.5'
+    kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
+
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 }
 
 // Apply the PESDKPlugin

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MediaActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MediaActivity.kt
@@ -16,6 +16,7 @@ import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.MenuItemCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -43,6 +44,8 @@ import com.simplemobiletools.gallery.pro.models.Medium
 import com.simplemobiletools.gallery.pro.models.ThumbnailItem
 import com.simplemobiletools.gallery.pro.models.ThumbnailSection
 import kotlinx.android.synthetic.main.activity_media.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
 import java.util.*
@@ -497,7 +500,7 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
     private fun restoreAllFiles() {
         val paths = mMedia.filter { it is Medium }.map { (it as Medium).path } as ArrayList<String>
         restoreRecycleBinPaths(paths) {
-            ensureBackgroundThread {
+            lifecycleScope.launch(Dispatchers.IO) {
                 directoryDao.deleteDirPath(RECYCLE_BIN)
             }
             finish()
@@ -590,7 +593,7 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
             }
 
             if (mPath == FAVORITES) {
-                ensureBackgroundThread {
+                lifecycleScope.launch(Dispatchers.IO) {
                     directoryDao.deleteDirPath(FAVORITES)
                 }
             }
@@ -603,7 +606,7 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
     }
 
     private fun deleteDBDirectory() {
-        ensureBackgroundThread {
+        lifecycleScope.launch(Dispatchers.IO) {
             try {
                 directoryDao.deleteDirPath(mPath)
             } catch (ignored: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SimpleActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SimpleActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.provider.MediaStore.Images
 import android.provider.MediaStore.Video
 import android.view.WindowManager
+import androidx.lifecycle.lifecycleScope
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.dialogs.FilePickerDialog
 import com.simplemobiletools.commons.extensions.getParentPath
@@ -17,6 +18,7 @@ import com.simplemobiletools.gallery.pro.R
 import com.simplemobiletools.gallery.pro.extensions.addPathToDB
 import com.simplemobiletools.gallery.pro.extensions.config
 import com.simplemobiletools.gallery.pro.extensions.updateDirectoryPath
+import kotlinx.coroutines.launch
 
 open class SimpleActivity : BaseSimpleActivity() {
     val observer = object : ContentObserver(null) {
@@ -24,7 +26,9 @@ open class SimpleActivity : BaseSimpleActivity() {
             super.onChange(selfChange, uri)
             val path = getRealPathFromURI(uri)
             if (path != null) {
-                updateDirectoryPath(path.getParentPath())
+                lifecycleScope.launch {
+                    updateDirectoryPath(path.getParentPath())
+                }
                 addPathToDB(path)
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
@@ -9,6 +9,7 @@ import android.graphics.drawable.Icon
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.google.gson.Gson
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
@@ -40,6 +41,8 @@ import kotlinx.android.synthetic.main.directory_item_grid.view.dir_pin
 import kotlinx.android.synthetic.main.directory_item_grid.view.dir_thumbnail
 import kotlinx.android.synthetic.main.directory_item_grid.view.photo_cnt
 import kotlinx.android.synthetic.main.directory_item_list.view.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.File
 
 class DirectoryAdapter(activity: BaseSimpleActivity, var dirs: ArrayList<Directory>, val listener: DirectoryOperationsListener?, recyclerView: MyRecyclerView,
@@ -197,7 +200,7 @@ class DirectoryAdapter(activity: BaseSimpleActivity, var dirs: ArrayList<Directo
                                 tmb = File(it, tmb.getFilenameFromPath()).absolutePath
                             }
                             updateDirs(dirs)
-                            ensureBackgroundThread {
+                            activity.lifecycleScope.launch(Dispatchers.IO) {
                                 try {
                                     activity.directoryDao.updateDirectoryAfterRename(firstDir.tmb, firstDir.name, firstDir.path, sourcePath)
                                     listener?.refreshItems()

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
@@ -2,6 +2,7 @@ package com.simplemobiletools.gallery.pro.dialogs
 
 import android.view.KeyEvent
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.dialogs.FilePickerDialog
@@ -13,6 +14,7 @@ import com.simplemobiletools.gallery.pro.extensions.*
 import com.simplemobiletools.gallery.pro.helpers.VIEW_TYPE_GRID
 import com.simplemobiletools.gallery.pro.models.Directory
 import kotlinx.android.synthetic.main.dialog_directory_picker.view.*
+import kotlinx.coroutines.launch
 
 class PickDirectoryDialog(val activity: BaseSimpleActivity, val sourcePath: String, showOtherFolderButton: Boolean, val showFavoritesBin: Boolean,
                           val callback: (path: String) -> Unit) {
@@ -62,14 +64,16 @@ class PickDirectoryDialog(val activity: BaseSimpleActivity, val sourcePath: Stri
     }
 
     private fun fetchDirectories(forceShowHidden: Boolean) {
-        activity.getCachedDirectories(forceShowHidden = forceShowHidden) {
-            if (it.isNotEmpty()) {
-                it.forEach {
-                    it.subfoldersMediaCount = it.mediaCnt
-                }
+        activity.lifecycleScope.launch {
+            activity.getCachedDirectories(forceShowHidden = forceShowHidden) {
+                if (it.isNotEmpty()) {
+                    it.forEach {
+                        it.subfoldersMediaCount = it.mediaCnt
+                    }
 
-                activity.runOnUiThread {
-                    gotDirectories(activity.addTempFolderIfNeeded(it))
+                    activity.runOnUiThread {
+                        gotDirectories(activity.addTempFolderIfNeeded(it))
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -17,6 +17,7 @@ import android.provider.MediaStore.Images
 import android.util.DisplayMetrics
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -34,6 +35,8 @@ import com.simplemobiletools.gallery.pro.dialogs.PickDirectoryDialog
 import com.simplemobiletools.gallery.pro.helpers.RECYCLE_BIN
 import com.simplemobiletools.gallery.pro.models.DateTaken
 import com.squareup.picasso.Picasso
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
@@ -363,7 +366,9 @@ fun BaseSimpleActivity.emptyTheRecycleBin(callback: (() -> Unit)? = null) {
         try {
             recycleBin.deleteRecursively()
             mediaDB.clearRecycleBin()
-            directoryDao.deleteRecycleBin()
+            lifecycleScope.launch(Dispatchers.IO) {
+                directoryDao.deleteRecycleBin()
+            }
             toast(R.string.recycle_bin_emptied)
             callback?.invoke()
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/helpers/MyWidgetProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/helpers/MyWidgetProvider.kt
@@ -22,8 +22,11 @@ import com.simplemobiletools.gallery.pro.extensions.directoryDao
 import com.simplemobiletools.gallery.pro.extensions.getFolderNameFromPath
 import com.simplemobiletools.gallery.pro.extensions.widgetsDB
 import com.simplemobiletools.gallery.pro.models.Widget
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-class MyWidgetProvider : AppWidgetProvider() {
+class MyWidgetProvider : AppWidgetProvider(), CoroutineScope by CoroutineScope(Dispatchers.Main) {
     private fun setupAppOpenIntent(context: Context, views: RemoteViews, id: Int, widget: Widget) {
         val intent = Intent(context, MediaActivity::class.java).apply {
             putExtra(DIRECTORY, widget.folderPath)
@@ -35,7 +38,7 @@ class MyWidgetProvider : AppWidgetProvider() {
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         super.onUpdate(context, appWidgetManager, appWidgetIds)
-        ensureBackgroundThread {
+        launch(Dispatchers.IO) {
             val config = context.config
             context.widgetsDB.getWidgets().filter { appWidgetIds.contains(it.widgetId) }.forEach {
                 val views = RemoteViews(context.packageName, R.layout.widget).apply {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/interfaces/DirectoryDao.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/interfaces/DirectoryDao.kt
@@ -10,26 +10,26 @@ import com.simplemobiletools.gallery.pro.models.Directory
 @Dao
 interface DirectoryDao {
     @Query("SELECT path, thumbnail, filename, media_count, last_modified, date_taken, size, location, media_types, sort_value FROM directories")
-    fun getAll(): List<Directory>
+    suspend fun getAll(): List<Directory>
 
     @Insert(onConflict = REPLACE)
-    fun insert(directory: Directory)
+    suspend fun insert(directory: Directory)
 
     @Insert(onConflict = REPLACE)
-    fun insertAll(directories: List<Directory>)
+    suspend fun insertAll(directories: List<Directory>)
 
     @Query("DELETE FROM directories WHERE path = :path COLLATE NOCASE")
-    fun deleteDirPath(path: String)
+    suspend fun deleteDirPath(path: String)
 
     @Query("UPDATE OR REPLACE directories SET thumbnail = :thumbnail, media_count = :mediaCnt, last_modified = :lastModified, date_taken = :dateTaken, size = :size, media_types = :mediaTypes, sort_value = :sortValue WHERE path = :path COLLATE NOCASE")
-    fun updateDirectory(path: String, thumbnail: String, mediaCnt: Int, lastModified: Long, dateTaken: Long, size: Long, mediaTypes: Int, sortValue: String)
+    suspend fun updateDirectory(path: String, thumbnail: String, mediaCnt: Int, lastModified: Long, dateTaken: Long, size: Long, mediaTypes: Int, sortValue: String)
 
     @Query("UPDATE directories SET thumbnail = :thumbnail, filename = :name, path = :newPath WHERE path = :oldPath COLLATE NOCASE")
-    fun updateDirectoryAfterRename(thumbnail: String, name: String, newPath: String, oldPath: String)
+    suspend fun updateDirectoryAfterRename(thumbnail: String, name: String, newPath: String, oldPath: String)
 
     @Query("DELETE FROM directories WHERE path = \'$RECYCLE_BIN\' COLLATE NOCASE")
-    fun deleteRecycleBin()
+    suspend fun deleteRecycleBin()
 
     @Query("SELECT thumbnail FROM directories WHERE path = :path")
-    fun getDirectoryThumbnail(path: String): String?
+    suspend fun getDirectoryThumbnail(path: String): String?
 }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/jobs/NewPhotoFetcher.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/jobs/NewPhotoFetcher.kt
@@ -20,10 +20,13 @@ import com.simplemobiletools.commons.extensions.getStringValue
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.gallery.pro.extensions.addPathToDB
 import com.simplemobiletools.gallery.pro.extensions.updateDirectoryPath
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 // based on https://developer.android.com/reference/android/app/job/JobInfo.Builder.html#addTriggerContentUri(android.app.job.JobInfo.TriggerContentUri)
 @TargetApi(Build.VERSION_CODES.N)
-class NewPhotoFetcher : JobService() {
+class NewPhotoFetcher : JobService(), CoroutineScope by CoroutineScope(Dispatchers.Main) {
     companion object {
         const val PHOTO_VIDEO_CONTENT_JOB = 1
         private val MEDIA_URI = Uri.parse("content://${MediaStore.AUTHORITY}/")
@@ -103,7 +106,9 @@ class NewPhotoFetcher : JobService() {
             }
 
             affectedFolderPaths.forEach {
-                updateDirectoryPath(it)
+                launch(Dispatchers.IO) {
+                    updateDirectoryPath(it)
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/receivers/BootCompletedReceiver.kt
@@ -3,13 +3,15 @@ package com.simplemobiletools.gallery.pro.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.gallery.pro.extensions.updateDirectoryPath
 import com.simplemobiletools.gallery.pro.helpers.MediaFetcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-class BootCompletedReceiver : BroadcastReceiver() {
+class BootCompletedReceiver : BroadcastReceiver(), CoroutineScope by CoroutineScope(Dispatchers.IO) {
     override fun onReceive(context: Context, intent: Intent) {
-        ensureBackgroundThread {
+        launch {
             MediaFetcher(context).getFoldersToScan().forEach {
                 context.updateDirectoryPath(it)
             }


### PR DESCRIPTION
Convert the DAO methods in `DirectoryDao` to suspend functions to prevent them being called on the main thread. Only the methods in `DirectoryDao` were converted to keep the PR as simple as possible, with the hope of converting the others in separate PRs.

Unlike the previous PRs, the methods are called using the I/O dispatcher, which is backed by a thread pool used for I/O tasks and [is recommended for use with Room](https://developer.android.com/kotlin/coroutines-adv#main-safety).