### PR TITLE
remove okhttp dependency from runtime classpath to save appsize

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,11 @@ dependencies {
     implementation 'com.google.vr:sdk-videowidget:1.180.0'
     implementation 'org.apache.sanselan:sanselan:0.97-incubator'
     implementation 'info.androidhive:imagefilters:1.0.7'
-    implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation('com.squareup.picasso:picasso:2.71828') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    }
+    compileOnly 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.squareup.okio:okio:2.10.0'
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation 'com.github.tibbi:gestureviews:a8e8fa8d27'
     implementation 'com.github.tibbi:subsampling-scale-image-view:961f7b5f2d'

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/App.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/App.kt
@@ -3,11 +3,23 @@ package com.simplemobiletools.gallery.pro
 import android.app.Application
 import com.github.ajalt.reprint.core.Reprint
 import com.simplemobiletools.commons.extensions.checkUseEnglish
+import com.squareup.picasso.Downloader
+import com.squareup.picasso.Picasso
+import okhttp3.Response
 
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
         checkUseEnglish()
         Reprint.initialize(this)
+        Picasso.setSingletonInstance(Picasso.Builder(this).downloader(object: Downloader {
+            override fun load(request: okhttp3.Request): Response {
+                return Response.Builder().build()
+            }
+
+            override fun shutdown() {
+
+            }
+        }).build())
     }
 }


### PR DESCRIPTION
OkHttp is pulled in by Picasso as a transitive dependency, but this app doesn't even have the internet permission, so it makes no sense to ship a whole networking library with the apk.

This change saves **133kB** in apk size for the floss-release flavor.

reference https://github.com/square/picasso/issues/2192

ps: Do you think it is possible to remove either Picasso or Glide completely from the app? Why was it necessary to have 2 image loaders in the first place?