### PR TITLE
enable R8 fullmode and cleanup shrinker rules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ android {
         }
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             if (keystorePropertiesFile.exists()) {
                 signingConfig signingConfigs.release
             }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,20 +1,3 @@
--keep class com.simplemobiletools.** { *; }
--dontwarn android.graphics.Canvas
--dontwarn com.simplemobiletools.**
--dontwarn org.apache.**
-
-# Picasso
--dontwarn javax.annotation.**
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
--dontwarn org.codehaus.mojo.animal_sniffer.*
--dontwarn okhttp3.internal.platform.ConscryptPlatform
-
--keepclassmembers class * implements android.os.Parcelable {
-    static ** CREATOR;
-}
-
-# RenderScript
--keepclasseswithmembernames class * {
-native <methods>;
-}
--keep class androidx.renderscript.** { *; }
+# preserve line numbers for crash reporting
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+android.enableR8.fullMode=true


### PR DESCRIPTION
This change reduces apk size by **589kB** on the fossRelease variant. 
I used the app with these changes for a while with no problems. I might not have used all features though.