### PR TITLE
enable shrinkResources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ android {
         }
         release {
             minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             if (keystorePropertiesFile.exists()) {
                 signingConfig signingConfigs.release


### PR DESCRIPTION
This reduces the apk size of the flossRelease variant by **330kB** without changing any functionality.