### PR TITLE
Avoid SQLite connection object leaking

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/databases/GalleryDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/databases/GalleryDatabase.kt
@@ -44,10 +44,8 @@ abstract class GalleryDatabase : RoomDatabase() {
         }
 
         fun destroyInstance() {
-            if (db != null) {
-                if(db!!.isOpen) {
-                    db?.close();
-                }
+            if (db?.isOpen == true) {
+                db?.close()
             }
             db = null
         }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/databases/GalleryDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/databases/GalleryDatabase.kt
@@ -44,6 +44,11 @@ abstract class GalleryDatabase : RoomDatabase() {
         }
 
         fun destroyInstance() {
+            if (db != null) {
+                if(db!!.isOpen) {
+                    db?.close();
+                }
+            }
             db = null
         }
 


### PR DESCRIPTION
 - W/SQLiteConnectionPool: A SQLiteConnection object for database '/data/user/0/com.simplemobiletools.gallery.pro/databases/gallery.db' was leaked!  Please fix your application to end transactions in progress properly and to close the database when it is no longer needed.

Happens to me on Android 11 (Moto g 5G plus, with Google Photos disabled):
 - open Camera, then click on the small picture thumbnail from bottom-right corner which should open the Gallery app
 - in this scenario sometimes, the Simple Gallery was crashing and the above warning was seen in the logs...
 - no more crash after this patch: please review/test properly before incorporating!