### PR TITLE
Fixed missing permission for rotate on external memory (#2236)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
@@ -307,36 +307,37 @@ class MediaAdapter(
         }
     }
 
-    private fun rotateSelection(degrees: Int) {
-        val paths = getSelectedPaths().filter { it.isImageFast() }
+    private fun handleRotate(paths: List<String>, degrees: Int) {
         var fileCnt = paths.size
         rotatedImagePaths.clear()
-        val handleRotate = {
-            activity.toast(R.string.saving)
-            ensureBackgroundThread {
-                paths.forEach {
-                    rotatedImagePaths.add(it)
-                    activity.saveRotatedImageToFile(it, it, degrees, true) {
-                        fileCnt--
-                        if (fileCnt == 0) {
-                            activity.runOnUiThread {
-                                listener?.refreshItems()
-                                finishActMode()
-                            }
+        activity.toast(R.string.saving)
+        ensureBackgroundThread {
+            paths.forEach {
+                rotatedImagePaths.add(it)
+                activity.saveRotatedImageToFile(it, it, degrees, true) {
+                    fileCnt--
+                    if (fileCnt == 0) {
+                        activity.runOnUiThread {
+                            listener?.refreshItems()
+                            finishActMode()
                         }
                     }
                 }
             }
         }
+    }
+
+    private fun rotateSelection(degrees: Int) {
+        val paths = getSelectedPaths().filter { it.isImageFast() }
 
         if (paths.any { activity.needsStupidWritePermissions(it) }) {
             activity.handleSAFDialog(paths.first { activity.needsStupidWritePermissions(it) }) {
                 if (it) {
-                    handleRotate()
+                    handleRotate(paths, degrees)
                 }
             }
         } else {
-            handleRotate()
+            handleRotate(paths, degrees)
         }
     }
 


### PR DESCRIPTION
Hi,

For every action that was saving anything on external memory, the app was checking permission and asking for it if needed. However, it wasn't done for batch rotating, so I've added it. It's done similarly as in other places. 

Some small notes about implementation:
- We are always rotating in the same directory, so it's enough to check permission for just one file.
- To not repeat the code between handleSAFDialog callback and no permissions required, I've moved the rotation code to a variable holding a function.
- I've moved "Saving" toast to be displayed just before saving, not at the start of the function.

**Before:**

https://user-images.githubusercontent.com/85929121/140605444-ba0b7eaf-ba94-4c98-9237-219d3d0a58b9.mp4

**After:**

https://user-images.githubusercontent.com/85929121/140605451-a5d1b573-2b8d-4fe7-9ec7-d79be5a3b6fc.mp4

