### PR TITLE
SDK 30 changes

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
@@ -626,9 +626,9 @@ class DirectoryAdapter(
                 return@handleSAFDialog
             }
 
-            activity.handleSAFDeleteSdk30Dialog(SAFPath){
+            activity.handleSAFDialogSdk30(SAFPath){
                 if (!it) {
-                    return@handleSAFDeleteSdk30Dialog
+                    return@handleSAFDialogSdk30
                 }
 
                 var foldersToDelete = ArrayList<File>(selectedKeys.size)

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
@@ -468,9 +468,9 @@ class MediaAdapter(
             }
 
             val sdk30SafPath = selectedPaths.firstOrNull { activity.isAccessibleWithSAFSdk30(it) } ?: getFirstSelectedItemPath() ?: return@handleSAFDialog
-            activity.handleSAFDeleteSdk30Dialog(sdk30SafPath){
+            activity.handleSAFDialogSdk30(sdk30SafPath){
                 if (!it) {
-                    return@handleSAFDeleteSdk30Dialog
+                    return@handleSAFDialogSdk30
                 }
 
                 val fileDirItems = ArrayList<FileDirItem>(selectedKeys.size)

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
@@ -7,6 +7,7 @@ import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.dialogs.FilePickerDialog
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.VIEW_TYPE_GRID
+import com.simplemobiletools.commons.helpers.isRPlus
 import com.simplemobiletools.commons.views.MyGridLayoutManager
 import com.simplemobiletools.gallery.pro.R
 import com.simplemobiletools.gallery.pro.adapters.DirectoryAdapter
@@ -109,6 +110,9 @@ class PickDirectoryDialog(
             if (clickedDir.subfoldersCount == 1 || !activity.config.groupDirectSubfolders) {
                 if (path.trimEnd('/') == sourcePath) {
                     activity.toast(R.string.source_and_destination_same)
+                    return@DirectoryAdapter
+                } else if (isRPlus() && path.isBasePath(activity)) {
+                    activity.toast(R.string.copy_to_restricted_folder_message)
                     return@DirectoryAdapter
                 } else {
                     activity.handleLockedFolderOpening(path) { success ->

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -250,7 +250,11 @@ fun BaseSimpleActivity.tryCopyMoveFilesTo(fileDirItems: ArrayList<FileDirItem>, 
         val destination = it
         handleSAFDialog(source) {
             if (it) {
-                copyMoveFilesTo(fileDirItems, source.trimEnd('/'), destination, isCopyOperation, true, config.shouldShowHidden, callback)
+                handleSAFDialogSdk30(fileDirItems[0].path){
+                    if (it) {
+                        copyMoveFilesTo(fileDirItems, source.trimEnd('/'), destination, isCopyOperation, true, config.shouldShowHidden, callback)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">تعيين كمجلد افتراضي</string>
     <string name="unset_as_default_folder">إلغاء التعيين كمجلد افتراضي</string>
     <string name="reorder_by_dragging">إعادة ترتيب المجلدات عن طريق السحب</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">فلترة الوسائط</string>
     <string name="images">الصور</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">ডিফল্ট ফোল্ডার হিশেবে সেট করুন</string>
     <string name="unset_as_default_folder">ডিফল্ট ফোল্ডার হিশেবে আর রাখবেন না</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">মিডিয়া ফিল্টার করুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Estableix com a carpeta predeterminada</string>
     <string name="unset_as_default_folder">Desactiva com a carpeta predeterminada</string>
     <string name="reorder_by_dragging">Reordeneu les carpetes arrossegant-les</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtre multimèdia</string>
     <string name="images">Imatges</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtr médií</string>
     <string name="images">Obrázky</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Vælg som standardmappe</string>
     <string name="unset_as_default_folder">Fravælg som standardmappe</string>
     <string name="reorder_by_dragging">Omorganiser mapper ved at trække</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtrer medier</string>
     <string name="images">Billeder</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Als Standardordner festlegen</string>
     <string name="unset_as_default_folder">Nicht mehr als Standardordner festlegen</string>
     <string name="reorder_by_dragging">Neuordnung von Ordnern durch Ziehen</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filter</string>
     <string name="images">Bilder</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Ορισμός ως προεπιλεγμένου φακέλου</string>
     <string name="unset_as_default_folder">Κατάργηση ως προεπιλεγμένου φακέλου</string>
     <string name="reorder_by_dragging">Αναδιάταξη φακέλων με μεταφορά</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Φιλτράρισμα πολυμέσων</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
     <!-- Filter -->
     <string name="filter_media">Filter media</string>
     <string name="images">Bildoj</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Poner como carpeta predeterminada</string>
     <string name="unset_as_default_folder">Quitar como carpeta predeterminada</string>
     <string name="reorder_by_dragging">Reordenar carpetas arrastrándolas</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtro de medios</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filter media</string>
     <string name="images">Pildid</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Ezarri lehenetsitako karpeta gisa</string>
     <string name="unset_as_default_folder">Kendu karpeta lehenetsitako karpeta gisa</string>
     <string name="reorder_by_dragging">Berrordenatu karpetak arrastatuz</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Iragazi multimedia</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">تنظیم به عنوان شاخهٔ پیش‌گزیده</string>
     <string name="unset_as_default_folder">برداشتن تنظیم به عنوان شاخهٔ پیش‌گزیده</string>
     <string name="reorder_by_dragging">مرتب‌سازی مجدد شاخه‌ها با کشیدن</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">پالایش رسانه</string>
     <string name="images">تصاویر</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Aseta oletushakemistoksi</string>
     <string name="unset_as_default_folder">Älä käytä oletushakemistona</string>
     <string name="reorder_by_dragging">Järjestä kansiot uudelleen vetämällä</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Suodata media</string>
     <string name="images">Kuvat</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Dossier par défaut</string>
     <string name="unset_as_default_folder">Oublier le dossier</string>
     <string name="reorder_by_dragging">Réordonner par glisser</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtrer les médias</string>
     <string name="images">Images</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtrar medios</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtriranje medija</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Beállítás alapértelmezett mappaként</string>
     <string name="unset_as_default_folder">Eltávolítás mint alapértelmezett mappa</string>
     <string name="reorder_by_dragging">Mappák átrendezése húzással</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Médiafájlok szűrése</string>
     <string name="images">Képek</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filter media</string>
     <string name="images">Gambar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Imposta come cartella predefinita</string>
     <string name="unset_as_default_folder">Non impostare come cartella predefinita</string>
     <string name="reorder_by_dragging">Riordina cartelle trascinandole</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
     <!-- Filter -->
     <string name="filter_media">Filtra i file</string>
     <string name="images">Immagini</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">デフォルトのフォルダとして設定</string>
     <string name="unset_as_default_folder">デフォルトのフォルダから外す</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">表示する形式</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">필터 설정</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtruoti mediją</string>
     <string name="images">Paveikslai</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Sett som standardmappe</string>
     <string name="unset_as_default_folder">Ikke lenger sett som standardmappe</string>
     <string name="reorder_by_dragging">Endre mapperekkefølge ved å dra</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtrer media</string>
     <string name="images">Bilder</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -35,6 +35,8 @@
     <string name="set_as_default_folder">Als standaardmap instellen</string>
     <string name="unset_as_default_folder">Standaardmap herstellen</string>
     <string name="reorder_by_dragging">Volgorde mappen bepalen met sleepgebaren</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Media filteren</string>
     <string name="images">Afbeeldingen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Ustaw jako folder domyślny</string>
     <string name="unset_as_default_folder">Anuluj ustawienie folderu domyślnego</string>
     <string name="reorder_by_dragging">Przeorganizuj foldery przeciągając</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtruj multimedia</string>
     <string name="images">Obrazy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Definir como pasta padrão</string>
     <string name="unset_as_default_folder">Indefinir como pasta padrão</string>
     <string name="reorder_by_dragging">Reordenar as pastas ao arrastar</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtrar mídia</string>
     <string name="images">Imagens</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Utilizar como pasta padrão</string>
     <string name="unset_as_default_folder">Deixar de utilizar como pasta padrão</string>
     <string name="reorder_by_dragging">Organizar pasta por arrasto</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Filtrar multimédia</string>
     <string name="images">Imagens</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Setază ca dosar implicit</string>
     <string name="unset_as_default_folder">Dezactivează ca dosar implicit</string>
     <string name="reorder_by_dragging">Reordonează dosarele prin tragere</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtrează elementele media</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -33,6 +33,8 @@
     <string name="set_as_default_folder">Установить как папку по умолчанию</string>
     <string name="unset_as_default_folder">Отключить как папку по умолчанию</string>
     <string name="reorder_by_dragging">Менять порядок папок перетаскиванием</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Фильтр медиа</string>
     <string name="images">Изображения</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Nastaviť ako predvolený priečinok</string>
     <string name="unset_as_default_folder">Odobrať predvolený priečinok</string>
     <string name="reorder_by_dragging">Zmeniť poradie priečinkov presunutím</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter médií</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtriranje datotek</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Филтрирај медију</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtrera media</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">இயல்புநிலை அடைவாக அமை</string>
     <string name="unset_as_default_folder">இயல்புநிலை அடைவாக அமைக்காதே</string>
     <string name="reorder_by_dragging">பிடித்திழுத்து அடைவுகளை மறுசீரமை</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">ஊடகத்தை வடிகட்டு</string>
     <string name="images">படங்கள்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -39,6 +39,8 @@
     <string name="set_as_default_folder">Öntanımlı klasör olarak ayarla</string>
     <string name="unset_as_default_folder">Öntanımlı klasör ayarını kaldır</string>
     <string name="reorder_by_dragging">Sürükleyerek klasörleri yeniden sırala</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
+
     <!-- Filter -->
     <string name="filter_media">Medyayı filtrele</string>
     <string name="images">Resimler</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Встановити теку за замовчуванням</string>
     <string name="unset_as_default_folder">Відмінити встановлення теки за замовчуванням</string>
     <string name="reorder_by_dragging">Сортувати папки шляхом переміщення</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Фільтр мультимедійних файлів</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Lọc</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,6 +39,7 @@
     <string name="set_as_default_folder">设置为默认文件夹</string>
     <string name="unset_as_default_folder">取消设置为默认文件夹</string>
     <string name="reorder_by_dragging">通过拖动重新排序文件夹</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
     <!-- Filter -->
     <string name="filter_media">筛选媒体文件</string>
     <string name="images">图片</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">篩選媒體檔案</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">設為預設資料夾</string>
     <string name="unset_as_default_folder">取消設為預設資料夾</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">篩選媒體檔案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="set_as_default_folder">Set as default folder</string>
     <string name="unset_as_default_folder">Unset as default folder</string>
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
+    <string name="copy_to_restricted_folder_message">Unable to use this folder.\nThe system does not allow us to copy/move to this folder</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>


### PR DESCRIPTION
**Notes**
- show an error when a user tries to pick the root directory of any volume
- the error shown is the string `copy_to_restricted_folder_message` which has the text `Unable to use this folder.\nThe system does not allow us to copy/move to this folder``
- handle SAF for SDK 30 before copying/moving files
