### PR TITLE
request ACCESS_MEDIA_LOCATION permission

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MainActivity.kt
@@ -145,10 +145,19 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
         }
 
         // just request the permission, tryLoadGallery will then trigger in onResume
-        handlePermission(PERMISSION_WRITE_STORAGE) {
+        handleMediaPermissions {
             if (!it) {
                 toast(R.string.no_storage_permissions)
                 finish()
+            }
+        }
+    }
+
+    private fun handleMediaPermissions(callback: (granted: Boolean) -> Unit) {
+        handlePermission(PERMISSION_WRITE_STORAGE) { granted ->
+            callback(granted)
+            if (granted && isSPlus()) {
+                handlePermission(PERMISSION_MEDIA_LOCATION) {}
             }
         }
     }
@@ -435,9 +444,9 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
     private fun tryLoadGallery() {
         // avoid calling anything right after granting the permission, it will be called from onResume()
         val wasMissingPermission = config.appRunCount == 1 && !hasPermission(PERMISSION_WRITE_STORAGE)
-        handlePermission(PERMISSION_WRITE_STORAGE) {
+        handleMediaPermissions {
             if (wasMissingPermission) {
-                return@handlePermission
+                return@handleMediaPermissions
             }
 
             if (it) {


### PR DESCRIPTION
### Notes
- these changes affect devices on Android 12 and above. See [documentation](https://developer.android.com/training/data-storage/shared/media#management-permission)
- the app has declared the `MANAGE_MEDIA` permission in the `AndroidManifest`
- also requesting the `ACCESS_MEDIA_LOCATION` permission will make the system not show the user the prompts from `MediaStore.createWriteRequest` and `MediaStore.createDeleteRequest`
- need to update commons after the related [PR](https://github.com/SimpleMobileTools/Simple-Commons/pull/1375) has been merged

**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/163484379-1fde5bd5-c5a8-4f1c-be5f-aaaf6d2d7b7b.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/163484490-9ee6e484-1fad-4a88-8350-c700a4f463c7.mp4" width="320"/>








