### PR TITLE
handle picking restricted folders in PickDirectoryDialog

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
@@ -8,7 +8,6 @@ import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.dialogs.FilePickerDialog
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.VIEW_TYPE_GRID
-import com.simplemobiletools.commons.helpers.isRPlus
 import com.simplemobiletools.commons.views.MyGridLayoutManager
 import com.simplemobiletools.gallery.pro.R
 import com.simplemobiletools.gallery.pro.adapters.DirectoryAdapter
@@ -112,7 +111,7 @@ class PickDirectoryDialog(
                 if (path.trimEnd('/') == sourcePath) {
                     activity.toast(R.string.source_and_destination_same)
                     return@DirectoryAdapter
-                } else if (isRPlus() && activity.isAStorageRootFolder(path)) {
+                } else if (activity.isRestrictedWithSAFSdk30(path) && !activity.isInDownloadDir(path)) {
                     activity.toast(R.string.system_folder_restriction, Toast.LENGTH_LONG)
                     return@DirectoryAdapter
                 } else {


### PR DESCRIPTION
### Notes
- users should not be able to pick restricted folders in `PickDirectoryDialog` when copying/moving files on SDK 30+
- show nice error message `R.string.system_folder_restriction` when a user picks a restricted folder on SDK 30+
- restricted folders on SDK 30+ are:
           - `Android`
           -  Root of Internal and SDCard. 
     The `Download` directory is writable
     
**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/163669361-106b72de-9f5d-4c16-a105-d9f9c98918c2.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/163669374-f47a254b-a4e3-404d-a20e-6cad61edeb74.mp4" width="320"/>







