### PR TITLE
fix media store crash on deletion on android 12

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -591,6 +591,7 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
             showSystemUI(true)
             mSlideshowHandler.removeCallbacksAndMessages(null)
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            mAreSlideShowMediaVisible = false
         }
     }
 
@@ -1128,16 +1129,21 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
                 }
 
                 mIgnoredPaths.add(fileDirItem.path)
-                val media = mMediaFiles.filter { !mIgnoredPaths.contains(it.path) } as ArrayList<ThumbnailItem>
-                runOnUiThread {
-                    gotMedia(media, true, false)
+                val media = mMediaFiles.filter { !mIgnoredPaths.contains(it.path) } as ArrayList<Medium>
+                if (media.isNotEmpty()) {
+                    runOnUiThread {
+                        refreshUI(media, true)
+                    }
                 }
 
                 movePathsInRecycleBin(arrayListOf(path)) {
                     if (it) {
                         tryDeleteFileDirItem(fileDirItem, false, false) {
                             mIgnoredPaths.remove(fileDirItem.path)
-                            deleteDirectoryIfEmpty()
+                            if (media.isEmpty()) {
+                                deleteDirectoryIfEmpty()
+                                finish()
+                            }
                         }
                     } else {
                         toast(R.string.unknown_error_occurred)
@@ -1156,14 +1162,19 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
             }
 
             mIgnoredPaths.add(fileDirItem.path)
-            val media = mMediaFiles.filter { !mIgnoredPaths.contains(it.path) } as ArrayList<ThumbnailItem>
-            runOnUiThread {
-                gotMedia(media, true, false)
+            val media = mMediaFiles.filter { !mIgnoredPaths.contains(it.path) } as ArrayList<Medium>
+            if (media.isNotEmpty()) {
+                runOnUiThread {
+                    refreshUI(media, true)
+                }
             }
 
             tryDeleteFileDirItem(fileDirItem, false, true) {
                 mIgnoredPaths.remove(fileDirItem.path)
-                deleteDirectoryIfEmpty()
+                if (media.isEmpty()) {
+                    deleteDirectoryIfEmpty()
+                    finish()
+                }
             }
         }
     }
@@ -1227,6 +1238,10 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
             return
         }
 
+        refreshUI(media, refetchViewPagerPosition)
+    }
+
+    private fun refreshUI(media: ArrayList<Medium>, refetchViewPagerPosition: Boolean) {
         mPrevHashcode = media.hashCode()
         mMediaFiles = media
 


### PR DESCRIPTION
## Notes
- MediaStore crashed on deletion because the `ViewPagerActivity` got finished before the `MediaStore.createDeleteRequest `executes completely
- To fix, we apply the same approach in the `MediaActivity` and finish explicitly after deletion completes, if the media list is empty
- also, only refresh the UI when the media list is not empty to avoid UI glitches
- fix the slideshow bug by resetting `mAreSlideShowMediaVisible` back to `false` when the slideshow ends
- closes #2454


**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/168409270-fad5a29e-0ecd-4bf0-bb9f-6ea2efc7e41a.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/168409271-29c90842-5587-42fc-9b26-238d8dc636b0.mp4" width="320"/>







