### PR TITLE
fix: position returning to 0

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -1136,7 +1136,7 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
                 val media = mMediaFiles.filter { !mIgnoredPaths.contains(it.path) } as ArrayList<Medium>
                 if (media.isNotEmpty()) {
                     runOnUiThread {
-                        refreshUI(media, true)
+                        refreshUI(media, false)
                     }
                 }
 
@@ -1169,7 +1169,7 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
             val media = mMediaFiles.filter { !mIgnoredPaths.contains(it.path) } as ArrayList<Medium>
             if (media.isNotEmpty()) {
                 runOnUiThread {
-                    refreshUI(media, true)
+                    refreshUI(media, false)
                 }
             }
 
@@ -1413,7 +1413,11 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
 
     private fun getCurrentPath() = getCurrentMedium()?.path ?: ""
 
-    override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
+    override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+        if (position == 0) {
+            onPageSelected(0)
+        }
+    }
 
     override fun onPageSelected(position: Int) {
         if (mPos != position) {


### PR DESCRIPTION
## Notes
- for calling  `refreshUI(media, true)` would refresh the view pager position, cause `mPos` to be set back to 0,
so we retain the original behaviour and call `refreshUI(media, false)`
- when items have been removed up until there is one item in the adapter, the ViewPager's `OnPageChangeListener.onPageSelected` does not get called for the first item (`position=0`)
so `mPos` is never set to zero and deletion fails.
- we add a call in `OnPageChangeListener.onPageScrolled` to call` onPageSelected(0)`, when the `position == 0` to fix this.