### PR TITLE
fix: position returning to 0 after moving file

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -1232,7 +1232,7 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
     private fun refreshViewPager() {
         if (config.getFolderSorting(mDirectory) and SORT_BY_RANDOM == 0) {
             GetMediaAsynctask(applicationContext, mDirectory, false, false, mShowAll) {
-                gotMedia(it, refetchViewPagerPosition = true)
+                gotMedia(it, refetchViewPagerPosition = false)
             }.execute()
         }
     }


### PR DESCRIPTION
##Notes
- fix  position returning to 0 after moving file
- related to [this Commons PR](https://github.com/SimpleMobileTools/Simple-Commons/pull/1416)
- closes [this issue](https://github.com/SimpleMobileTools/Simple-Gallery/issues/2470)

**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/170144817-b10d90fa-e5c9-4ae6-bfd5-41fae91eed8d.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/170145277-03a4e6e3-e272-4865-84e6-67b3b90fae48.mov" width="320"/>












