### PR TITLE
excluded folders should not enforce storage restrictions on SDK 30+

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ExcludedFoldersActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ExcludedFoldersActivity.kt
@@ -60,7 +60,15 @@ class ExcludedFoldersActivity : SimpleActivity(), RefreshRecyclerViewListener {
     }
 
     private fun addFolder() {
-        FilePickerDialog(this, internalStoragePath, false, config.shouldShowHidden, false, true) {
+        FilePickerDialog(
+            activity = this,
+            internalStoragePath,
+            pickFile = false,
+            config.shouldShowHidden,
+            showFAB = false,
+            canAddShowHiddenButton = true,
+            enforceStorageRestrictions = false,
+        ) {
             config.lastFilepickerPath = it
             config.addExcludedFolder(it)
             updateFolders()


### PR DESCRIPTION
## Notes
- related to the changes in the [Simple-Commons module](https://github.com/SimpleMobileTools/Simple-Commons/pull/1419)

Android 11 device

**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/170462055-a23b0f75-10b0-4fb7-a0b6-e5628790d6a4.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/170462031-80f94b62-1401-475f-9631-dc1b22a0a3a6.mp4" width="320"/>







