### PR TITLE
[feat] - Replace original file after edit

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/SaveAsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/SaveAsDialog.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.gallery.pro.dialogs
 
+import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.dialogs.ConfirmationDialog
@@ -19,6 +20,16 @@ class SaveAsDialog(
         var realPath = path.getParentPath()
         if (activity.isRestrictedWithSAFSdk30(realPath) && !activity.isInDownloadDir(realPath)) {
             realPath = activity.getPicturesDirectoryPath(realPath)
+        }
+
+        val alertDialogBuilder = AlertDialog.Builder(activity)
+        var alertDialog: AlertDialog? = null
+        val originalFullName = when {
+            appendFilename -> path.getFilenameFromPath()
+            else           -> {
+                val tempFullName = path.getFilenameFromPath()
+                tempFullName.substring(0, tempFullName.lastIndexOf(".")).dropLast("_1".length) + tempFullName.substring(tempFullName.lastIndexOf("."))
+            }
         }
 
         val view = activity.layoutInflater.inflate(R.layout.dialog_save_as, null).apply {
@@ -46,60 +57,87 @@ class SaveAsDialog(
                     realPath = it
                 }
             }
-        }
-
-        AlertDialog.Builder(activity)
-            .setPositiveButton(R.string.ok, null)
-            .setNegativeButton(R.string.cancel) { dialog, which -> cancelCallback?.invoke() }
-            .setOnCancelListener { cancelCallback?.invoke() }
-            .create().apply {
-                activity.setupDialogStuff(view, this, R.string.save_as) {
-                    showKeyboard(view.save_as_name)
-                    getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
-                        val filename = view.save_as_name.value
-                        val extension = view.save_as_extension.value
-
-                        if (filename.isEmpty()) {
-                            activity.toast(R.string.filename_cannot_be_empty)
-                            return@setOnClickListener
-                        }
-
-                        if (extension.isEmpty()) {
-                            activity.toast(R.string.extension_cannot_be_empty)
-                            return@setOnClickListener
-                        }
-
-                        val newFilename = "$filename.$extension"
-                        val newPath = "${realPath.trimEnd('/')}/$newFilename"
-                        if (!newFilename.isAValidFilename()) {
-                            activity.toast(R.string.filename_invalid_characters)
-                            return@setOnClickListener
-                        }
-
-                        if (activity.getDoesFilePathExist(newPath)) {
-                            val title = String.format(activity.getString(R.string.file_already_exists_overwrite), newFilename)
-                            ConfirmationDialog(activity, title) {
-                                val newFile = File(newPath)
-                                val isInDownloadDir = activity.isInDownloadDir(newPath)
-                                val isInSubFolderInDownloadDir = activity.isInSubFolderInDownloadDir(newPath)
-                                if ((isRPlus() && !isExternalStorageManager()) && isInDownloadDir && !isInSubFolderInDownloadDir && !newFile.canWrite()) {
-                                    val fileDirItem = arrayListOf(File(newPath).toFileDirItem(activity))
-                                    val fileUris = activity.getFileUrisFromFileDirItems(fileDirItem)
-                                    activity.updateSDK30Uris(fileUris) { success ->
-                                        if (success) {
-                                            selectPath(this, newPath)
-                                        }
-                                    }
-                                } else {
-                                    selectPath(this, newPath)
-                                }
-                            }
-                        } else {
-                            selectPath(this, newPath)
-                        }
+            replace_original.setOnCheckedChangeListener { _, isChecked ->
+                run {
+                    toggleViewFocusability(save_as_name)
+                    toggleViewFocusability(save_as_path)
+                    toggleViewFocusability(save_as_extension)
+                    if (isChecked) {
+                        alertDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.text = context.getString(R.string.pesdk_sticker_button_replace)
+                    } else {
+                        alertDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.text = context.getString(R.string.ok)
                     }
                 }
             }
+        }
+
+        alertDialogBuilder
+            .setPositiveButton(R.string.ok, null)
+            .setNegativeButton(R.string.cancel) { dialog, which -> cancelCallback?.invoke() }
+            .setOnCancelListener { cancelCallback?.invoke() }
+        alertDialog = alertDialogBuilder.create()
+        alertDialog.apply {
+            activity.setupDialogStuff(view, this, R.string.save_as) {
+                showKeyboard(view.save_as_name)
+                getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                    val filename = view.save_as_name.value
+                    val extension = view.save_as_extension.value
+
+                    if (view.replace_original.isChecked) {
+                        overwriteFile("${realPath.trimEnd('/')}/$originalFullName")
+                        return@setOnClickListener
+                    }
+
+                    if (filename.isEmpty()) {
+                        activity.toast(R.string.filename_cannot_be_empty)
+                        return@setOnClickListener
+                    }
+                    if (extension.isEmpty()) {
+                        activity.toast(R.string.extension_cannot_be_empty)
+                        return@setOnClickListener
+                    }
+
+                    val newFilename = "$filename.$extension"
+                    val newPath = "${realPath.trimEnd('/')}/$newFilename"
+                    if (!newFilename.isAValidFilename()) {
+                        activity.toast(R.string.filename_invalid_characters)
+                        return@setOnClickListener
+                    }
+
+                    if (activity.getDoesFilePathExist(newPath)) {
+                        val title = String.format(activity.getString(R.string.file_already_exists_overwrite), newFilename)
+                        ConfirmationDialog(activity, title) {
+                            overwriteFile(newPath)
+                        }
+                    } else {
+                        selectPath(this, newPath)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun AlertDialog.overwriteFile(path: String) {
+        val newFile = File(path)
+        val isInDownloadDir = activity.isInDownloadDir(path)
+        val isInSubFolderInDownloadDir = activity.isInSubFolderInDownloadDir(path)
+        if (isRPlus() && isInDownloadDir && !isInSubFolderInDownloadDir && !newFile.canWrite()) {
+            val fileDirItem = arrayListOf(File(path).toFileDirItem(activity))
+            val fileUris = activity.getFileUrisFromFileDirItems(fileDirItem)
+            activity.updateSDK30Uris(fileUris) { success ->
+                if (success) {
+                    selectPath(this, path)
+                }
+            }
+        } else {
+            selectPath(this, path)
+        }
+    }
+
+    private fun toggleViewFocusability(view: View?) {
+        val viewIsEnabled = view?.isEnabled
+        view?.isEnabled = !viewIsEnabled!!
+        view.isFocusableInTouchMode = !viewIsEnabled
     }
 
     private fun selectPath(alertDialog: AlertDialog, newPath: String) {

--- a/app/src/main/res/layout/dialog_save_as.xml
+++ b/app/src/main/res/layout/dialog_save_as.xml
@@ -50,4 +50,12 @@
         android:textCursorDrawable="@null"
         android:textSize="@dimen/normal_text_size" />
 
+    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+        android:id="@+id/replace_original"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/activity_margin"
+        android:paddingBottom="@dimen/activity_margin"
+        android:text="@string/replace_original_file" />
+
 </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">إعادة ترتيب المجلدات عن طريق السحب</string>
     <string name="reorder_by_dragging_pro">إعادة ترتيب المجلدات عن طريق السحب (Pro)</string>
     <string name="restore_to_path">الاستعادة إلى \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">فلترة الوسائط</string>
     <string name="images">الصور</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -82,6 +82,7 @@
     <string name="show_on_map">Show on map</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <string name="filter_media">Filter media</string>
     <string name="images">Images</string>
     <string name="exclude_folder_parent">Exclude a parent instead\?</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Пренаредете папките с влачене</string>
     <string name="reorder_by_dragging_pro">Пренаредете папките с влачене (Pro)</string>
     <string name="restore_to_path">Възстановяване в \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Филтър на медия</string>
     <string name="images">Изображения</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">মিডিয়া ফিল্টার করুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Reordeneu les carpetes arrossegant-les</string>
     <string name="reorder_by_dragging_pro">Reordeneu les carpetes arrossegant-les (Pro)</string>
     <string name="restore_to_path">S\'està restaurant a «%s»</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtre multimèdia</string>
     <string name="images">Imatges</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtr médií</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Omorganiser mapper ved at trække</string>
     <string name="reorder_by_dragging_pro">Omorganiser mapper ved at trække (Pro)</string>
     <string name="restore_to_path">Gendanner til \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtrer medier</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Neuordnung von Ordnern durch Ziehen</string>
     <string name="reorder_by_dragging_pro">Neuordnung von Ordnern durch Ziehen (Pro)</string>
     <string name="restore_to_path">Wiederherstellung nach „%s“</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Medien filtern</string>
     <string name="images">Bilder</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Αναδιάταξη φακέλων με μεταφορά</string>
     <string name="reorder_by_dragging_pro">Αναδιάταξη φακέλων με μεταφορά (Pro)</string>
     <string name="restore_to_path">Επαναφορά σε \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Φιλτράρισμα πολυμέσων</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filter media</string>
     <string name="images">Bildoj</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reordenar carpetas arrastrándolas</string>
     <string name="reorder_by_dragging_pro">Reordenar carpetas arrastrándolas (Pro)</string>
     <string name="restore_to_path">Restaurando a \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtro de medios</string>
     <string name="images">Imágenes</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Muuda kaustade järjekorda lohistades</string>
     <string name="reorder_by_dragging_pro">Muuda kaustade järjekorda lohistades (Pro)</string>
     <string name="restore_to_path">Taastame kausta „%s“</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filter media</string>
     <string name="images">Pildid</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Berrordenatu karpetak arrastatuz</string>
     <string name="reorder_by_dragging_pro">Berrordenatu karpetak arrastatuz (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Iragazi multimedia</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">مرتب‌سازی مجدد شاخه‌ها با کشیدن</string>
     <string name="reorder_by_dragging_pro">مرتب‌سازی مجدد شاخه‌ها با کشیدن (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">پالایش رسانه</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Järjestä kansiot uudelleen vetämällä</string>
     <string name="reorder_by_dragging_pro">Järjestä kansiot uudelleen vetämällä (Pro)</string>
     <string name="restore_to_path">Palautetaan kohteeseen \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Suodata media</string>
     <string name="images">Kuvat</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Réordonner par glisser</string>
     <string name="reorder_by_dragging_pro">Réordonner par glisser (Pro)</string>
     <string name="restore_to_path">Restauration vers « %s »</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtrer les médias</string>
     <string name="images">Images</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtrar medios</string>
     <string name="images">Imaxes</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Promijeni redoslijed mapa povlačenjem</string>
     <string name="reorder_by_dragging_pro">Promijeni redoslijed mapa povlačenjem (Pro)</string>
     <string name="restore_to_path">Obnavlja se u „%s”</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtar medija</string>
     <string name="images">Slike</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Mappák átrendezése húzással</string>
     <string name="reorder_by_dragging_pro">Mappák átrendezése húzással (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Médiafájlok szűrése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Susun ulang folder dengan menyeret</string>
     <string name="reorder_by_dragging_pro">Susun ulang folder dengan menyeret (Pro)</string>
     <string name="restore_to_path">Memulihkan ke \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filter media</string>
     <string name="images">Gambar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Riordina cartelle trascinandole</string>
     <string name="reorder_by_dragging_pro">Riordina cartelle trascinandole (Pro)</string>
     <string name="restore_to_path">Ripristino a «%s»</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtra i file</string>
     <string name="images">Immagini</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">סדר מחדש את התיקיות על ידי גרירה</string>
     <string name="reorder_by_dragging_pro">סדר מחדש את התיקיות על ידי גרירה (Pro)</string>
     <string name="restore_to_path">משחזר ל\'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">סינון מדיה</string>
     <string name="images">תמונות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">表示する形式</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">필터 설정</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtruoti mediją</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Endre mapperekkefølge ved å dra</string>
     <string name="reorder_by_dragging_pro">Endre mapperekkefølge ved å dra (Pro)</string>
     <string name="restore_to_path">Gjenoppretter til \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtrer media</string>
     <string name="images">Bilder</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -37,6 +37,7 @@
     <string name="reorder_by_dragging">Volgorde mappen bepalen met sleepgebaren</string>
     <string name="reorder_by_dragging_pro">Volgorde mappen bepalen met sleepgebaren (Pro)</string>
     <string name="restore_to_path">Herstellen naar \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Media filteren</string>
     <string name="images">Afbeeldingen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Przeorganizuj foldery przeciągając</string>
     <string name="reorder_by_dragging_pro">Przeorganizuj foldery przeciągając (Pro)</string>
     <string name="restore_to_path">Przywracanie do „%s”</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtruj multimedia</string>
     <string name="images">Obrazy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Reordenar as pastas ao arrastar</string>
     <string name="reorder_by_dragging_pro">Reordenar as pastas ao arrastar (Pro)</string>
     <string name="restore_to_path">Restaurando para \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtrar mídia</string>
     <string name="images">Imagens</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Organizar pasta por arrasto</string>
     <string name="reorder_by_dragging_pro">Organizar pasta por arrasto (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtrar multimédia</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reordonează dosarele prin tragere</string>
     <string name="reorder_by_dragging_pro">Reordonează dosarele prin tragere (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtrează elementele media</string>
     <string name="images">Imagini</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Менять порядок папок перетаскиванием</string>
     <string name="reorder_by_dragging_pro">Менять порядок папок перетаскиванием (Pro)</string>
     <string name="restore_to_path">Восстановление в \"%s\"</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Фильтр медиа</string>
     <string name="images">Изображения</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Zmeniť poradie priečinkov presunutím</string>
     <string name="reorder_by_dragging_pro">Zmeniť poradie priečinkov presunutím (Pro)</string>
     <string name="restore_to_path">Obnovuje sa do \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter médií</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filtriranje datotek</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Филтрирај медију</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Filtrera media</string>
     <string name="images">Bilder</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">பிடித்திழுத்து அடைவுகளை மறுசீரமை</string>
     <string name="reorder_by_dragging_pro">பிடித்திழுத்து அடைவுகளை மறுசீரமை (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">ஊடகத்தை வடிகட்டு</string>
     <string name="images">படங்கள்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">Sürükleyerek klasörleri yeniden sırala</string>
     <string name="reorder_by_dragging_pro">Sürükleyerek klasörleri yeniden sırala (Pro)</string>
     <string name="restore_to_path">\'%s\' konumuna geri yükle</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Medyayı filtrele</string>
     <string name="images">Resimler</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Сортувати теки шляхом переміщення</string>
     <string name="reorder_by_dragging_pro">Сортувати теки шляхом переміщення (Pro)</string>
     <string name="restore_to_path">Відновлення в \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">Фільтр мультимедійних файлів</string>
     <string name="images">Зображення</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Lọc</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -41,6 +41,7 @@
     <string name="reorder_by_dragging">通过拖动重新排序文件夹</string>
     <string name="reorder_by_dragging_pro">通过拖动重新排序文件夹 (Pro)</string>
     <string name="restore_to_path">还原到 \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">筛选媒体文件</string>
     <string name="images">图片</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">篩選媒體檔案</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">透過拖曳來重新排序資料夾</string>
     <string name="reorder_by_dragging_pro">透過拖曳來重新排序資料夾 (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
     <!-- Filter -->
     <string name="filter_media">篩選媒體檔案</string>
     <string name="images">圖片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="replace_original_file">Replace original file</string>
 
     <!-- Filter -->
     <string name="filter_media">Filter media</string>


### PR DESCRIPTION
### Description
- Address feature request in issue #2438 
### Screenshot
![Screenshot_20220503-155649](https://user-images.githubusercontent.com/98877504/166457709-e7eab6f4-ad08-4faa-87b6-3a00197bcf57.jpg)

### Changes
- added a checkbox to the "save as" dialog that a user can tick in case the user wants to replace the original image when saving.
- upon ticking the checkbox the filename and extension fields are disabled.
- The dialog positive button is changed from "OK" to "Replace".
- When a user clicks "Replace", they are not prompted with the "overwrite confirmation" dialog (for the process of replacing to happen in fewer clicks, I imagine the user that selects "Replace Original File" option is already sure of what they want)