### PR TITLE
fix wrong rotation for horizontally flipped images

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/PhotoFragment.kt
@@ -22,6 +22,7 @@ import android.widget.RelativeLayout
 import androidx.exifinterface.media.ExifInterface.ORIENTATION_ROTATE_180
 import androidx.exifinterface.media.ExifInterface.ORIENTATION_ROTATE_270
 import androidx.exifinterface.media.ExifInterface.ORIENTATION_ROTATE_90
+import androidx.exifinterface.media.ExifInterface.ORIENTATION_TRANSVERSE
 import androidx.exifinterface.media.ExifInterface.TAG_ORIENTATION
 import com.alexvasilkov.gestures.GestureController
 import com.alexvasilkov.gestures.State
@@ -343,7 +344,7 @@ class PhotoFragment : ViewPagerFragment() {
     private fun degreesForRotation(orientation: Int) = when (orientation) {
         ORIENTATION_ROTATE_270 -> 270
         ORIENTATION_ROTATE_180 -> 180
-        ORIENTATION_ROTATE_90 -> 90
+        ORIENTATION_ROTATE_90, ORIENTATION_TRANSVERSE -> 90
         else -> 0
     }
 


### PR DESCRIPTION
# Why
Horizontally flipped images with orientation [`ORIENTATION_TRANSVERSE`](https://developer.android.com/reference/android/media/ExifInterface#ORIENTATION_TRANSVERSE) were rotated by 0 degs in the ViewPager screen. 
Ideally, they should be rotated by 90. 

This PR fixes it. 