### PR TITLE
Change search hint on the main screen according to the setting

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MainActivity.kt
@@ -245,6 +245,12 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
                 tryLoadGallery()
             }
         }
+
+        if (config.searchAllFilesByDefault) {
+            main_menu.updateHintText(getString(R.string.search_files))
+        } else {
+            main_menu.updateHintText(getString(R.string.search_folders))
+        }
     }
 
     override fun onPause() {
@@ -330,7 +336,6 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
         main_menu.getToolbar().inflateMenu(menuId)
         main_menu.toggleHideOnScroll(true)
         main_menu.setupMenu()
-        main_menu.updateHintText(getString(R.string.search_folders))
 
         if (isPiePlus()) {
             main_menu.onSearchOpenListener = {


### PR DESCRIPTION
Hi,

After setting on "Search all files instead of folders on the main screen", it's misleading that search still shows a hint "Search folders". I've decided to change it accordingly to the setting, so it won't be confusing.

https://user-images.githubusercontent.com/85929121/211811825-9e2d420e-193f-41df-82c7-a5818c9dc06c.mp4

