### PR TITLE
Always request write permission when updating existing file on 30+

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/EditActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/EditActivity.kt
@@ -873,11 +873,16 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
             ensureBackgroundThread {
                 val file = File(path)
                 val fileDirItem = FileDirItem(path, path.getFilenameFromPath())
-                getFileOutputStream(fileDirItem, true) {
-                    if (it != null) {
-                        saveBitmap(file, bitmap, it, showSavingToast)
-                    } else {
-                        toast(R.string.image_editing_failed)
+                try {
+                    val out = FileOutputStream(file)
+                    saveBitmap(file, bitmap, out, showSavingToast)
+                } catch (e: Exception) {
+                    getFileOutputStream(fileDirItem, true) {
+                        if (it != null) {
+                            saveBitmap(file, bitmap, it, showSavingToast)
+                        } else {
+                            toast(R.string.image_editing_failed)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/SaveAsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/SaveAsDialog.kt
@@ -78,10 +78,7 @@ class SaveAsDialog(
                         if (activity.getDoesFilePathExist(newPath)) {
                             val title = String.format(activity.getString(R.string.file_already_exists_overwrite), newFilename)
                             ConfirmationDialog(activity, title) {
-                                val newFile = File(newPath)
-                                val isInDownloadDir = activity.isInDownloadDir(newPath)
-                                val isInSubFolderInDownloadDir = activity.isInSubFolderInDownloadDir(newPath)
-                                if ((isRPlus() && !isExternalStorageManager()) && isInDownloadDir && !isInSubFolderInDownloadDir && !newFile.canWrite()) {
+                                if ((isRPlus() && !isExternalStorageManager())) {
                                     val fileDirItem = arrayListOf(File(newPath).toFileDirItem(activity))
                                     val fileUris = activity.getFileUrisFromFileDirItems(fileDirItem)
                                     activity.updateSDK30Uris(fileUris) { success ->


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Gallery/issues/2433

The code responsible for this glitch:
https://github.com/SimpleMobileTools/Simple-Gallery/blob/970eb5a03510a49878d1f6032b559599b6855294/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/SaveAsDialog.kt#L81-L91

At [line 84](https://github.com/SimpleMobileTools/Simple-Gallery/blob/970eb5a03510a49878d1f6032b559599b6855294/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/SaveAsDialog.kt#L84), it's not clear to me why we were requesting write access only if we are inside the download folder. This means if a file belongs to any other location then we don't request write access and the file is not properly updated. I have removed this download folder check.

A casual file output stream was needed to fix the file size update issue even after requesting write access (it's not the media store that wasn't properly updated, the file size on the disk stayed the same after cropping/resizing images)
