### PR TITLE
Add strings related to resizing multiple images

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">تعديل</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">يرجى إدخال دقة صالحة</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">الارتفاع</string>
     <string name="keep_aspect_ratio">الحفاظ على نسبة الأبعاد</string>
     <string name="invalid_values">يرجى إدخال دقة صالحة</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">تعديل</string>
     <string name="basic_editor">المحرر الأساسي</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Height</string>
     <string name="keep_aspect_ratio">Keep aspect ratio</string>
     <string name="invalid_values">Please enter a valid resolution</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Please enter a valid resolution</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -99,6 +99,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <string name="rotate">Павярнуць</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -98,7 +98,7 @@
     <string name="invalid_values">Увядзіце сапраўднае рашэнне</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -96,6 +96,11 @@
     <string name="height">Вышыня</string>
     <string name="keep_aspect_ratio">Захоўвайце суадносіны бакоў</string>
     <string name="invalid_values">Увядзіце сапраўднае рашэнне</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <string name="rotate">Павярнуць</string>
     <string name="invalid_image_path">Няправільны шлях выявы</string>
     <string name="invalid_video_path">Няправільны шлях відэа</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -100,7 +100,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <string name="rotate">Павярнуць</string>
     <string name="invalid_image_path">Няправільны шлях выявы</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Височина</string>
     <string name="keep_aspect_ratio">Запазете съотношението на страните</string>
     <string name="invalid_values">Моля въведете валидна резолюция</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Редактор</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Редактор</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Моля въведете валидна резолюция</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">সম্পাদক</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">দৈর্ঘ্য</string>
     <string name="keep_aspect_ratio">অনুপাত রাখুন</string>
     <string name="invalid_values">দয়া করে একটি বৈধ রেজোলিউশন দিন।</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">সম্পাদক</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">দয়া করে একটি বৈধ রেজোলিউশন দিন।</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Introduïu una resolució vàlida</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Alçada</string>
     <string name="keep_aspect_ratio">Mantén la relació d\'aspecte</string>
     <string name="invalid_values">Introduïu una resolució vàlida</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Editor bàsic</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Prosím zadejte platné rozlišení</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Výška</string>
     <string name="keep_aspect_ratio">Zachovat poměr stran</string>
     <string name="invalid_values">Prosím zadejte platné rozlišení</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Základní editor</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Højde</string>
     <string name="keep_aspect_ratio">Bevar billedformat</string>
     <string name="invalid_values">Indtast en gyldig opløsning</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
 	<string name="basic_editor">Grundlæggende editor</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Indtast en gyldig opløsning</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Höhe</string>
     <string name="keep_aspect_ratio">Seitenverhältnis beibehalten</string>
     <string name="invalid_values">Bitte eine gültige Auflösung eingeben</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Einfacher Editor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Bitte eine gültige Auflösung eingeben</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Επεξεργαστής</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Παρακαλώ εισάγετε σωστή ανάλυση</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Ύψος</string>
     <string name="keep_aspect_ratio">Διατήρηση αναλογίας</string>
     <string name="invalid_values">Παρακαλώ εισάγετε σωστή ανάλυση</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Επεξεργαστής</string>
     <string name="basic_editor">Βασικός επεξεργαστής</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Height</string>
     <string name="keep_aspect_ratio">Keep aspect ratio</string>
     <string name="invalid_values">Please enter a valid resolution</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Please enter a valid resolution</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Alto</string>
     <string name="keep_aspect_ratio">Mantener proporciones</string>
     <string name="invalid_values">Por favor, introduzca una resolución válida</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Editor básico</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Por favor, introduzca una resolución válida</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Palun sisesta kehtiv resolutsioon</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Kõrgus</string>
     <string name="keep_aspect_ratio">Jäta proportsioon samaks</string>
     <string name="invalid_values">Palun sisesta kehtiv resolutsioon</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redaktor</string>
     <string name="basic_editor">Lihtne redaktor</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redaktor</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Altuera</string>
     <string name="keep_aspect_ratio">Mantendu aspektu-erlazioa</string>
     <string name="invalid_values">Sartu baliozko bereizmena</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editorea</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editorea</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Sartu baliozko bereizmena</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Height</string>
     <string name="keep_aspect_ratio">Keep aspect ratio</string>
     <string name="invalid_values">Please enter a valid resolution</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Please enter a valid resolution</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editori</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Aseta oikea resoluutio</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Korkeus</string>
     <string name="keep_aspect_ratio">Säilytä kuvasuhde</string>
     <string name="invalid_values">Aseta oikea resoluutio</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editori</string>
     <string name="basic_editor">Peruseditori</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Veuillez entrer une résolution valide</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Hauteur</string>
     <string name="keep_aspect_ratio">Conserver le rapport d\'affichage</string>
     <string name="invalid_values">Veuillez entrer une résolution valide</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Éditeur</string>
     <string name="basic_editor">Éditeur simple</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Éditeur</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Por favor escribe unha resolución válida</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Alto</string>
     <string name="keep_aspect_ratio">Manter proporcións</string>
     <string name="invalid_values">Por favor escribe unha resolución válida</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Editor básico</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Uređivač</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Visina</string>
     <string name="keep_aspect_ratio">Zadrži omjer</string>
     <string name="invalid_values">Upiši valjanu rezoluciju</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Uređivač</string>
     <string name="basic_editor">Osnovni uređivač</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Upiši valjanu rezoluciju</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Szerkesztő</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Magasság</string>
     <string name="keep_aspect_ratio">Képarány megtartása</string>
     <string name="invalid_values">Írjon be érvényes felbontást</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Szerkesztő</string>
     <string name="basic_editor">Alapvető szerkesztő</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Írjon be érvényes felbontást</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Silakan masukkan resolusi yang valid</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Tinggi</string>
     <string name="keep_aspect_ratio">Jaga aspek rasio</string>
     <string name="invalid_values">Silakan masukkan resolusi yang valid</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Penyunting</string>
     <string name="basic_editor">Penyunting Dasar</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Penyunting</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Inserisci una risoluzione valida</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Altezza</string>
     <string name="keep_aspect_ratio">Mantieni proporzioni</string>
     <string name="invalid_values">Inserisci una risoluzione valida</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Editor di base</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">נא להזין החלטה חוקית</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">עורך</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">גובה</string>
     <string name="keep_aspect_ratio">שמור על יחס רוחב-גובה</string>
     <string name="invalid_values">נא להזין החלטה חוקית</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">עורך</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -71,7 +71,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">編集</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -69,7 +69,7 @@
     <string name="invalid_values">解像度を正しく入力してください</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,6 +67,11 @@
     <string name="height">高さ</string>
     <string name="keep_aspect_ratio">縦横比を固定</string>
     <string name="invalid_values">解像度を正しく入力してください</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">編集</string>
     <string name="basic_editor">基本的な編集</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -70,6 +70,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">세로</string>
     <string name="keep_aspect_ratio">비율 유지</string>
     <string name="invalid_values">잘못된 비율입니다.</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">편집</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">편집</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">잘못된 비율입니다.</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -68,6 +68,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -65,6 +65,11 @@
     <string name="height">Aukštis</string>
     <string name="keep_aspect_ratio">Išlaikyti proporcijas</string>
     <string name="invalid_values">Prašome įvesti tinkamą raišką</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redaktorius</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -69,7 +69,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redaktorius</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -67,7 +67,7 @@
     <string name="invalid_values">Prašome įvesti tinkamą raišką</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redigering</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Høyde</string>
     <string name="keep_aspect_ratio">Behold sideforhold</string>
     <string name="invalid_values">Oppfør en gyldig oppløsning</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redigering</string>
     <string name="basic_editor">Enkel redigering</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Oppfør en gyldig oppløsning</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">उचाई</string>
     <string name="keep_aspect_ratio">Keep aspect ratio</string>
     <string name="invalid_values">Please enter a valid resolution</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">सम्पादक</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">सम्पादक</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Please enter a valid resolution</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Voer geldige afmetingen in</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Hoogte</string>
     <string name="keep_aspect_ratio">Beeldverhouding vergrendelen</string>
     <string name="invalid_values">Voer geldige afmetingen in</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Bewerken</string>
     <string name="basic_editor">Eenvoudige bewerking</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Bewerken</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">ایڈیٹر</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Please enter a valid resolution</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">اُچائی</string>
     <string name="keep_aspect_ratio">Keep aspect ratio</string>
     <string name="invalid_values">Please enter a valid resolution</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">ایڈیٹر</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Edytor</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Podaj prawidłową rozdzielczość</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Wysokość</string>
     <string name="keep_aspect_ratio">Zachowaj proporcje</string>
     <string name="invalid_values">Podaj prawidłową rozdzielczość</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Edytor</string>
     <string name="basic_editor">Podstawowy edytor</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Digite uma resolução válida</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Altura</string>
     <string name="keep_aspect_ratio">Manter proporção</string>
     <string name="invalid_values">Digite uma resolução válida</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Editor básico</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Introduza uma resolução válida</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Altura</string>
     <string name="keep_aspect_ratio">Manter proporção</string>
     <string name="invalid_values">Introduza uma resolução válida</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Editor básico</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Înălțime</string>
     <string name="keep_aspect_ratio">Păstrează raportul de aspect</string>
     <string name="invalid_values">Vă rugăm să introduceți o rezoluție validă</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Vă rugăm să introduceți o rezoluție validă</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Редактор</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Высота</string>
     <string name="keep_aspect_ratio">Сохранять соотношение сторон</string>
     <string name="invalid_values">Указано недопустимое разрешение</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Редактор</string>
     <string name="basic_editor">Простой редактор</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Указано недопустимое разрешение</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Prosím zadajte platné rozlíšenie</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Výška</string>
     <string name="keep_aspect_ratio">Zachovať pomer strán</string>
     <string name="invalid_values">Prosím zadajte platné rozlíšenie</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Editor</string>
     <string name="basic_editor">Základný editor</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Višina</string>
     <string name="keep_aspect_ratio">Obdrži razmerje stranic</string>
     <string name="invalid_values">Vnesite veljavno ločljivost</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Urejevalnik</string>
     <string name="basic_editor">Osnovni urejevalnik</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Vnesite veljavno ločljivost</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Urejevalnik</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Унесите исправну резолуцију</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Висина</string>
     <string name="keep_aspect_ratio">Задржи пропорције</string>
     <string name="invalid_values">Унесите исправну резолуцију</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Едитор</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Едитор</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Höjd</string>
     <string name="keep_aspect_ratio">Behåll bildförhållande</string>
     <string name="invalid_values">Ange en giltig bildupplösning</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redigerare</string>
     <string name="basic_editor">Enkel redigerare</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Redigerare</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Ange en giltig bildupplösning</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">உயரம்</string>
     <string name="keep_aspect_ratio">கூறுவிகிதத்தை வைத்திரு</string>
     <string name="invalid_values">செல்லத்தக்க தீர்மானத்தை உள்ளிடவும்</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">திருத்தி</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">செல்லத்தக்க தீர்மானத்தை உள்ளிடவும்</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">திருத்தி</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Düzenleyici</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Lütfen geçerli bir çözünürlük girin</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Yükseklik</string>
     <string name="keep_aspect_ratio">En-boy oranını koru</string>
     <string name="invalid_values">Lütfen geçerli bir çözünürlük girin</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Düzenleyici</string>
     <string name="basic_editor">Temel Düzenleyici</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Введіть допустиму роздільну здатність</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Редактор</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Висота</string>
     <string name="keep_aspect_ratio">Зберігати співвідношення сторін</string>
     <string name="invalid_values">Введіть допустиму роздільну здатність</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Редактор</string>
     <string name="basic_editor">Базовий редактор</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Trình biên tập</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Chiều cao</string>
     <string name="keep_aspect_ratio">Giữ tỷ lệ khung hình</string>
     <string name="invalid_values">Vui lòng nhập độ phân giải hợp lệ</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">Trình biên tập</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Vui lòng nhập độ phân giải hợp lệ</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">请输入有效的分辨率</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">高度</string>
     <string name="keep_aspect_ratio">保持高宽比</string>
     <string name="invalid_values">请输入有效的分辨率</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">编辑器</string>
     <string name="basic_editor">基础编辑器</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">编辑器</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -71,6 +71,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -72,7 +72,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">編輯器</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -70,7 +70,7 @@
     <string name="invalid_values">請輸入有效的解析度</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -68,6 +68,11 @@
     <string name="height">高度</string>
     <string name="keep_aspect_ratio">保持長寬比</string>
     <string name="invalid_values">請輸入有效的解析度</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">編輯器</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">高度</string>
     <string name="keep_aspect_ratio">保持長寬比</string>
     <string name="invalid_values">請輸入有效的解析度</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">編輯器</string>
     <string name="basic_editor">Basic Editor</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->
     <string name="editor">編輯器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">請輸入有效的解析度</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
     <!-- Editor -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,11 @@
     <string name="height">Height</string>
     <string name="keep_aspect_ratio">Keep aspect ratio</string>
     <string name="invalid_values">Please enter a valid resolution</string>
+    <string name="resize_multiple_images">Resize multiple images</string>
+    <string name="resize_factor">Resize factor</string>
+    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <string name="images_resized_successfully">Images resized successfully</string>
 
     <!-- Editor -->
     <string name="editor">Editor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,10 @@
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
-    <string name="failed_to_resize_images">Failed to resize %d images</string>
+    <plurals name="failed_to_resize_images">
+        <item quantity="one">Failed to resize %d image</item>
+        <item quantity="other">Failed to resize %d images</item>
+    </plurals>
     <string name="images_resized_successfully">Images resized successfully</string>
 
     <!-- Editor -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="invalid_values">Please enter a valid resolution</string>
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
-    <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_info">Resize images to the given percentage, value must be within 10 and 90.</string>
     <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="resize_multiple_images">Resize multiple images</string>
     <string name="resize_factor">Resize factor</string>
     <string name="resize_factor_info">Please enter a number between 10 and 90 to specify the percentage factor by which the image resolution will be reduced.</string>
+    <string name="resize_factor_error">Enter a number between 10 and 90</string>
     <string name="failed_to_resize_images">Failed to resize %d images</string>
     <string name="images_resized_successfully">Images resized successfully</string>
 


### PR DESCRIPTION
`Enter a number between 10 and 90`: Used when the user enters a number outside the 10-90 range.
`Failed to resize %d images`: Used to show a toast when resizing some or all images failed.

<img src="https://github.com/SimpleMobileTools/Simple-Gallery/assets/36371707/2797b8ce-0f9e-41ae-affb-d156719bd98d" width=264 />

<img src="https://github.com/SimpleMobileTools/Simple-Gallery/assets/36371707/d6586139-ee2a-4231-b0cc-03746f1c2005" width=264 />
