### PR TITLE
Add option to bulk resize images

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -1045,35 +1045,9 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.N)
     private fun resizeImage() {
         val oldPath = getCurrentPath()
         launchResizeImageDialog(oldPath)
-    }
-
-    @TargetApi(Build.VERSION_CODES.N)
-    private fun saveBitmap(file: File, bitmap: Bitmap, out: OutputStream, oldExif: ExifInterface?, lastModified: Long) {
-        try {
-            bitmap.compress(file.absolutePath.getCompressionFormat(), 90, out)
-
-            if (isNougatPlus()) {
-                val newExif = ExifInterface(file.absolutePath)
-                oldExif?.copyNonDimensionAttributesTo(newExif)
-            }
-        } catch (e: Exception) {
-        }
-
-        toast(R.string.file_saved)
-        val paths = arrayListOf(file.absolutePath)
-        rescanPaths(paths) {
-            fixDateTaken(paths, false)
-
-            if (config.keepLastModified && lastModified != 0L) {
-                File(file.absolutePath).setLastModified(lastModified)
-                updateLastModified(file.absolutePath, lastModified)
-            }
-        }
-        out.close()
     }
 
     private fun checkDeleteConfirmation() {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/ViewPagerActivity.kt
@@ -16,7 +16,6 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Icon
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -47,7 +46,6 @@ import com.simplemobiletools.gallery.pro.R
 import com.simplemobiletools.gallery.pro.adapters.MyPagerAdapter
 import com.simplemobiletools.gallery.pro.asynctasks.GetMediaAsynctask
 import com.simplemobiletools.gallery.pro.dialogs.DeleteWithRememberDialog
-import com.simplemobiletools.gallery.pro.dialogs.ResizeWithPathDialog
 import com.simplemobiletools.gallery.pro.dialogs.SaveAsDialog
 import com.simplemobiletools.gallery.pro.dialogs.SlideshowDialog
 import com.simplemobiletools.gallery.pro.extensions.*
@@ -1050,34 +1048,7 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
     @TargetApi(Build.VERSION_CODES.N)
     private fun resizeImage() {
         val oldPath = getCurrentPath()
-        val originalSize = oldPath.getImageResolution(this) ?: return
-        ResizeWithPathDialog(this, originalSize, oldPath) { newSize, newPath ->
-            ensureBackgroundThread {
-                try {
-                    var oldExif: ExifInterface? = null
-                    if (isNougatPlus()) {
-                        val inputStream = contentResolver.openInputStream(Uri.fromFile(File(oldPath)))
-                        oldExif = ExifInterface(inputStream!!)
-                    }
-
-                    val newBitmap = Glide.with(applicationContext).asBitmap().load(oldPath).submit(newSize.x, newSize.y).get()
-
-                    val newFile = File(newPath)
-                    val newFileDirItem = FileDirItem(newPath, newPath.getFilenameFromPath())
-                    getFileOutputStream(newFileDirItem, true) {
-                        if (it != null) {
-                            saveBitmap(newFile, newBitmap, it, oldExif, File(oldPath).lastModified())
-                        } else {
-                            toast(R.string.image_editing_failed)
-                        }
-                    }
-                } catch (e: OutOfMemoryError) {
-                    toast(R.string.out_of_memory_error)
-                } catch (e: Exception) {
-                    showErrorToast(e)
-                }
-            }
-        }
+        launchResizeImageDialog(oldPath)
     }
 
     @TargetApi(Build.VERSION_CODES.N)

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
@@ -144,6 +144,7 @@ class MediaAdapter(
             findItem(R.id.cab_open_with).isVisible = isOneItemSelected
             findItem(R.id.cab_edit).isVisible = isOneItemSelected
             findItem(R.id.cab_set_as).isVisible = isOneItemSelected
+            findItem(R.id.cab_resize).isVisible = selectedItems.all { it.isImage() }
             findItem(R.id.cab_confirm_selection).isVisible = isAGetIntent && allowMultiplePicks && selectedKeys.isNotEmpty()
             findItem(R.id.cab_restore_recycle_bin_files).isVisible = selectedPaths.all { it.startsWith(activity.recycleBinPath) }
             findItem(R.id.cab_create_shortcut).isVisible = isOreoPlus() && isOneItemSelected
@@ -179,6 +180,7 @@ class MediaAdapter(
             R.id.cab_open_with -> openPath()
             R.id.cab_fix_date_taken -> fixDateTaken()
             R.id.cab_set_as -> setAs()
+            R.id.cab_resize -> resize()
             R.id.cab_delete -> checkDeleteConfirmation()
         }
     }
@@ -284,6 +286,20 @@ class MediaAdapter(
     private fun setAs() {
         val path = getFirstSelectedItemPath() ?: return
         activity.setAs(path)
+    }
+
+    private fun resize() {
+        val paths = getSelectedPaths()
+        if (isOneItemSelected()) {
+            val path = paths.first()
+            activity.launchResizeImageDialog(path) {
+                finishActMode()
+            }
+        } else {
+            activity.launchResizeMultipleImagesDialog(paths) {
+                finishActMode()
+            }
+        }
     }
 
     private fun toggleFileVisibility(hide: Boolean) {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/MediaAdapter.kt
@@ -302,9 +302,11 @@ class MediaAdapter(
         if (!selectionContainsImages) {
             return false
         }
-        val parentPath = selectedItems.first { it.isImage() }.path.getParentPath()
+
+        val parentPath = selectedItems.first { it.isImage() }.parentPath
+        val isCommonParent = selectedItems.all { parentPath == it.parentPath }
         val isRestrictedDir = activity.isRestrictedWithSAFSdk30(parentPath)
-        return !isRestrictedDir
+        return isExternalStorageManager() || (isCommonParent && !isRestrictedDir)
     }
 
     private fun toggleFileVisibility(hide: Boolean) {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
@@ -101,7 +101,7 @@ class ResizeMultipleImagesDialog(
 
                     val failureCount = imagePaths.size - pathsToRescan.size
                     if (failureCount > 0) {
-                        toast(getString(R.string.failed_to_resize_images, failureCount))
+                        toast(resources.getQuantityString(R.plurals.failed_to_resize_images, failureCount, failureCount))
                     } else {
                         toast(R.string.images_resized_successfully)
                     }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
@@ -10,15 +10,13 @@ import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.gallery.pro.R
-import com.simplemobiletools.gallery.pro.extensions.config
 import com.simplemobiletools.gallery.pro.extensions.ensureWriteAccess
-import com.simplemobiletools.gallery.pro.extensions.fixDateTaken
+import com.simplemobiletools.gallery.pro.extensions.rescanPathsAndUpdateLastModified
 import com.simplemobiletools.gallery.pro.extensions.resizeImage
 import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_factor_edit_text
 import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_factor_info
 import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_factor_input_layout
 import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_progress
-import java.io.File
 import kotlin.math.roundToInt
 
 private const val DEFAULT_RESIZE_FACTOR = "75"
@@ -113,17 +111,7 @@ class ResizeMultipleImagesDialog(
                         toast(R.string.images_resized_successfully)
                     }
 
-                    rescanPaths(pathsToRescan) {
-                        fixDateTaken(pathsToRescan, false)
-                        for (path in pathsToRescan) {
-                            val file = File(path)
-                            val lastModified = file.lastModified()
-                            if (config.keepLastModified && lastModified != 0L) {
-                                File(file.absolutePath).setLastModified(lastModified)
-                                updateLastModified(file.absolutePath, lastModified)
-                            }
-                        }
-                    }
+                    rescanPathsAndUpdateLastModified(pathsToRescan)
                     activity.runOnUiThread {
                         dialog?.dismiss()
                         callback.invoke()

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
@@ -1,0 +1,160 @@
+package com.simplemobiletools.gallery.pro.dialogs
+
+import android.graphics.Point
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.core.widget.doAfterTextChanged
+import com.simplemobiletools.commons.activities.BaseSimpleActivity
+import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.commons.helpers.ensureBackgroundThread
+import com.simplemobiletools.gallery.pro.R
+import com.simplemobiletools.gallery.pro.extensions.config
+import com.simplemobiletools.gallery.pro.extensions.ensureWriteAccess
+import com.simplemobiletools.gallery.pro.extensions.fixDateTaken
+import com.simplemobiletools.gallery.pro.extensions.resizeImage
+import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_factor_edit_text
+import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_factor_info
+import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_factor_input_layout
+import kotlinx.android.synthetic.main.dialog_resize_multiple_images.view.resize_progress
+import java.io.File
+import kotlin.math.roundToInt
+
+private const val DEFAULT_RESIZE_FACTOR = "75"
+private const val RESIZE_FACTOR_ERROR_DELAY = 800L
+
+class ResizeMultipleImagesDialog(
+    private val activity: BaseSimpleActivity,
+    private val imagePaths: List<String>,
+    private val imageSizes: List<Point>,
+    private val callback: () -> Unit
+) {
+
+    private var dialog: AlertDialog? = null
+    private val view = activity.layoutInflater.inflate(R.layout.dialog_resize_multiple_images, null)
+    private val progressView = view.resize_progress
+    private val resizeFactorEditText = view.resize_factor_edit_text
+
+    init {
+        setupViews(view)
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.ok, null)
+            .setNegativeButton(R.string.cancel, null)
+            .apply {
+                activity.setupDialogStuff(view, this, R.string.resize_multiple_images) { alertDialog ->
+                    dialog = alertDialog
+                    alertDialog.showKeyboard(resizeFactorEditText)
+
+                    val positiveButton = alertDialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    val negativeButton = alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                    positiveButton.setOnClickListener {
+                        val resizeFactorText = resizeFactorEditText.text?.toString()
+                        val resizeFactor = try {
+                            resizeFactorText?.toFloat()?.div(100)
+                        } catch (e: Exception) {
+                            null
+                        }
+
+                        if (resizeFactor == null) {
+                            activity.toast(R.string.resize_factor_error)
+                            return@setOnClickListener
+                        }
+
+                        alertDialog.setCanceledOnTouchOutside(false)
+                        arrayOf(view.resize_factor_input_layout, view.resize_factor_info, positiveButton, negativeButton).forEach {
+                            it.isEnabled = false
+                            it.alpha = 0.6f
+                        }
+                        resizeImages(resizeFactor)
+                    }
+                }
+            }
+    }
+
+    private fun resizeImages(factor: Float) {
+        progressView.show()
+        ensureBackgroundThread {
+            with(activity) {
+                val newSizes = imageSizes.map {
+                    val width = (it.x * factor).roundToInt()
+                    val height = (it.y * factor).roundToInt()
+                    Point(width, height)
+                }
+
+                val parentPath = imagePaths.first().getParentPath()
+                val pathsToRescan = arrayListOf<String>()
+
+                ensureWriteAccess(parentPath) {
+                    for (i in imagePaths.indices) {
+                        val path = imagePaths[i]
+                        val size = newSizes[i]
+
+                        try {
+                            resizeImage(path, size) {
+                                if (it) {
+                                    pathsToRescan.add(path)
+                                    runOnUiThread {
+                                        progressView.progress = i + 1
+                                    }
+                                }
+                            }
+                        } catch (e: OutOfMemoryError) {
+                            toast(R.string.out_of_memory_error)
+                        } catch (e: Exception) {
+                            showErrorToast(e)
+                        }
+                    }
+
+                    val failureCount = imagePaths.size - pathsToRescan.size
+                    if (failureCount > 0) {
+                        toast(getString(R.string.failed_to_resize_images, failureCount))
+                    } else {
+                        toast(R.string.images_resized_successfully)
+                    }
+
+                    rescanPaths(pathsToRescan) {
+                        fixDateTaken(pathsToRescan, false)
+                        for (path in pathsToRescan) {
+                            val file = File(path)
+                            val lastModified = file.lastModified()
+                            if (config.keepLastModified && lastModified != 0L) {
+                                File(file.absolutePath).setLastModified(lastModified)
+                                updateLastModified(file.absolutePath, lastModified)
+                            }
+                        }
+                    }
+                    activity.runOnUiThread {
+                        dialog?.dismiss()
+                        callback.invoke()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setupViews(view: View) {
+        val handler = Handler(Looper.getMainLooper())
+        val resizeFactorInputLayout = view.resize_factor_input_layout
+        view.resize_factor_edit_text.apply {
+            setText(DEFAULT_RESIZE_FACTOR)
+            doAfterTextChanged {
+                resizeFactorInputLayout.error = null
+                handler.removeCallbacksAndMessages(null)
+                handler.postDelayed({
+                    val factorText = it?.toString()
+                    if (factorText.isNullOrEmpty() || factorText.toInt() !in 10..90) {
+                        resizeFactorInputLayout.error = activity.getString(R.string.resize_factor_error)
+                    } else {
+                        resizeFactorInputLayout.error = null
+                    }
+                }, RESIZE_FACTOR_ERROR_DELAY)
+            }
+        }
+
+        progressView.apply {
+            max = imagePaths.size
+            setIndicatorColor(activity.getProperPrimaryColor())
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
@@ -67,18 +67,18 @@ class ResizeMultipleImagesDialog(
 
     private fun resizeImages(factor: Float) {
         progressView.show()
-        ensureBackgroundThread {
-            with(activity) {
-                val newSizes = imageSizes.map {
-                    val width = (it.x * factor).roundToInt()
-                    val height = (it.y * factor).roundToInt()
-                    Point(width, height)
-                }
+        with(activity) {
+            val newSizes = imageSizes.map {
+                val width = (it.x * factor).roundToInt()
+                val height = (it.y * factor).roundToInt()
+                Point(width, height)
+            }
 
-                val parentPath = imagePaths.first().getParentPath()
-                val pathsToRescan = arrayListOf<String>()
+            val parentPath = imagePaths.first().getParentPath()
+            val pathsToRescan = arrayListOf<String>()
 
-                ensureWriteAccess(parentPath) {
+            ensureWriteAccess(parentPath) {
+                ensureBackgroundThread {
                     for (i in imagePaths.indices) {
                         val path = imagePaths[i]
                         val size = newSizes[i]

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -772,7 +772,6 @@ fun BaseSimpleActivity.ensureWriteAccess(path: String, callback: () -> Unit) {
     }
 }
 
-@TargetApi(Build.VERSION_CODES.N)
 fun BaseSimpleActivity.launchResizeMultipleImagesDialog(paths: List<String>, callback: (() -> Unit)? = null) {
     ensureBackgroundThread {
         val imagePaths = mutableListOf<String>()
@@ -793,7 +792,6 @@ fun BaseSimpleActivity.launchResizeMultipleImagesDialog(paths: List<String>, cal
     }
 }
 
-@TargetApi(Build.VERSION_CODES.N)
 fun BaseSimpleActivity.launchResizeImageDialog(path: String, callback: (() -> Unit)? = null) {
     val originalSize = path.getImageResolution(this) ?: return
     ResizeWithPathDialog(this, originalSize, path) { newSize, newPath ->

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -747,6 +747,7 @@ fun BaseSimpleActivity.ensureWriteAccess(path: String, callback: () -> Unit) {
                 callback.invoke()
             }
         }
+
         needsStupidWritePermissions(path) -> {
             handleSAFDialog(path) {
                 if (!it) {
@@ -755,6 +756,7 @@ fun BaseSimpleActivity.ensureWriteAccess(path: String, callback: () -> Unit) {
                 callback()
             }
         }
+
         isAccessibleWithSAFSdk30(path) -> {
             handleSAFDialogSdk30(path) {
                 if (!it) {
@@ -763,6 +765,7 @@ fun BaseSimpleActivity.ensureWriteAccess(path: String, callback: () -> Unit) {
                 callback()
             }
         }
+
         else -> {
             callback()
         }
@@ -797,16 +800,8 @@ fun BaseSimpleActivity.launchResizeImageDialog(path: String, callback: (() -> Un
                         toast(R.string.file_saved)
 
                         val file = File(path)
-                        val lastModified = file.lastModified()
                         val paths = arrayListOf(file.absolutePath)
-                        rescanPaths(paths) {
-                            fixDateTaken(paths, false)
-                            if (config.keepLastModified && lastModified != 0L) {
-                                File(file.absolutePath).setLastModified(lastModified)
-                                updateLastModified(file.absolutePath, lastModified)
-                            }
-                        }
-
+                        rescanPathsAndUpdateLastModified(paths)
                         runOnUiThread {
                             callback?.invoke()
                         }
@@ -851,6 +846,20 @@ fun BaseSimpleActivity.resizeImage(path: String, size: Point, callback: (success
             }
         } else {
             callback(false)
+        }
+    }
+}
+
+fun BaseSimpleActivity.rescanPathsAndUpdateLastModified(paths: ArrayList<String>) {
+    rescanPaths(paths) {
+        fixDateTaken(paths, false)
+        for (path in paths) {
+            val file = File(path)
+            val lastModified = file.lastModified()
+            if (config.keepLastModified && lastModified != 0L) {
+                File(file.absolutePath).setLastModified(lastModified)
+                updateLastModified(file.absolutePath, lastModified)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -774,18 +774,22 @@ fun BaseSimpleActivity.ensureWriteAccess(path: String, callback: () -> Unit) {
 
 @TargetApi(Build.VERSION_CODES.N)
 fun BaseSimpleActivity.launchResizeMultipleImagesDialog(paths: List<String>, callback: (() -> Unit)? = null) {
-    val imagePaths = mutableListOf<String>()
-    val imageSizes = mutableListOf<Point>()
-    for (path in paths) {
-        val size = path.getImageResolution(this)
-        if (size != null) {
-            imagePaths.add(path)
-            imageSizes.add(size)
+    ensureBackgroundThread {
+        val imagePaths = mutableListOf<String>()
+        val imageSizes = mutableListOf<Point>()
+        for (path in paths) {
+            val size = path.getImageResolution(this)
+            if (size != null) {
+                imagePaths.add(path)
+                imageSizes.add(size)
+            }
         }
-    }
 
-    ResizeMultipleImagesDialog(this, imagePaths, imageSizes) {
-        callback?.invoke()
+        runOnUiThread {
+            ResizeMultipleImagesDialog(this, imagePaths, imageSizes) {
+                callback?.invoke()
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -823,35 +823,33 @@ fun BaseSimpleActivity.launchResizeImageDialog(path: String, callback: (() -> Un
 }
 
 fun BaseSimpleActivity.resizeImage(path: String, size: Point, callback: (success: Boolean) -> Unit) {
-    ensureBackgroundThread {
-        var oldExif: ExifInterface? = null
-        if (isNougatPlus()) {
-            val inputStream = contentResolver.openInputStream(Uri.fromFile(File(path)))
-            oldExif = ExifInterface(inputStream!!)
-        }
+    var oldExif: ExifInterface? = null
+    if (isNougatPlus()) {
+        val inputStream = contentResolver.openInputStream(Uri.fromFile(File(path)))
+        oldExif = ExifInterface(inputStream!!)
+    }
 
-        val newBitmap = Glide.with(applicationContext).asBitmap().load(path).submit(size.x, size.y).get()
+    val newBitmap = Glide.with(applicationContext).asBitmap().load(path).submit(size.x, size.y).get()
 
-        val newFile = File(path)
-        val newFileDirItem = FileDirItem(path, path.getFilenameFromPath())
-        getFileOutputStream(newFileDirItem, true) { out ->
-            if (out != null) {
-                out.use {
-                    try {
-                        newBitmap.compress(newFile.absolutePath.getCompressionFormat(), 90, out)
+    val newFile = File(path)
+    val newFileDirItem = FileDirItem(path, path.getFilenameFromPath())
+    getFileOutputStream(newFileDirItem, true) { out ->
+        if (out != null) {
+            out.use {
+                try {
+                    newBitmap.compress(newFile.absolutePath.getCompressionFormat(), 90, out)
 
-                        if (isNougatPlus()) {
-                            val newExif = ExifInterface(newFile.absolutePath)
-                            oldExif?.copyNonDimensionAttributesTo(newExif)
-                        }
-                    } catch (ignored: Exception) {
+                    if (isNougatPlus()) {
+                        val newExif = ExifInterface(newFile.absolutePath)
+                        oldExif?.copyNonDimensionAttributesTo(newExif)
                     }
-
-                    callback(true)
+                } catch (ignored: Exception) {
                 }
-            } else {
-                callback(false)
+
+                callback(true)
             }
+        } else {
+            callback(false)
         }
     }
 }

--- a/app/src/main/res/layout/dialog_resize_multiple_images.xml
+++ b/app/src/main/res/layout/dialog_resize_multiple_images.xml
@@ -14,27 +14,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.simplemobiletools.commons.views.MyTextView
-        android:id="@+id/resize_factor_info"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/big_margin"
-        android:layout_marginTop="@dimen/normal_margin"
-        android:text="@string/resize_factor_info"
-        android:textSize="@dimen/normal_text_size"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/resize_progress" />
-
     <com.simplemobiletools.commons.views.MyTextInputLayout
         android:id="@+id/resize_factor_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/big_margin"
-        android:layout_marginTop="@dimen/medium_margin"
+        android:layout_marginTop="@dimen/normal_margin"
         android:hint="@string/resize_factor"
         app:errorEnabled="true"
-        app:layout_constraintTop_toBottomOf="@id/resize_factor_info"
+        app:helperText="Resize images to the given percentage, value must be within 10 and 90"
+        app:helperTextEnabled="true"
+        app:layout_constraintTop_toBottomOf="@id/resize_progress"
         app:suffixText="%">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/dialog_resize_multiple_images.xml
+++ b/app/src/main/res/layout/dialog_resize_multiple_images.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/resize_progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/normal_margin"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.simplemobiletools.commons.views.MyTextView
+        android:id="@+id/resize_factor_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/big_margin"
+        android:layout_marginTop="@dimen/normal_margin"
+        android:text="@string/resize_factor_info"
+        android:textSize="@dimen/normal_text_size"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/resize_progress" />
+
+    <com.simplemobiletools.commons.views.MyTextInputLayout
+        android:id="@+id/resize_factor_input_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/big_margin"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:hint="@string/resize_factor"
+        app:errorEnabled="true"
+        app:layout_constraintTop_toBottomOf="@id/resize_factor_info"
+        app:suffixText="%">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/resize_factor_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:singleLine="true"
+            android:textCursorDrawable="@null"
+            android:textSize="@dimen/bigger_text_size" />
+
+    </com.simplemobiletools.commons.views.MyTextInputLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/cab_media.xml
+++ b/app/src/main/res/menu/cab_media.xml
@@ -84,6 +84,11 @@
         android:title="@string/set_as"
         app:showAsAction="never" />
     <item
+        android:id="@+id/cab_resize"
+        android:showAsAction="never"
+        android:title="@string/resize"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/cab_edit"
         android:icon="@drawable/ic_edit_vector"
         android:title="@string/edit"


### PR DESCRIPTION
Users can utilize this feature to resize images in bulk, doesn't matter how many. The option to bulk resize images is visible when the following conditions are met:

1. At least one image is selected (SVGs and GIFs do not qualify)
2. The parent directory of the selected images is not a restricted directory. For example, in Android 11, the Download folder is restricted. Alternatively, if the app has the "Manage all files" permission, the resize option will still be available even in restricted directories.
3. All selected images share a common parent directory. This means that the files were not selected while in "Show all folders" mode. However, if the app has the "Manage all files" permission, the resize option will be accessible regardless of whether the selected images have a common parent directory.

### Screenshots: 
<img src="https://github.com/SimpleMobileTools/Simple-Gallery/assets/36371707/2797b8ce-0f9e-41ae-affb-d156719bd98d" width=264 />

<img src="https://github.com/SimpleMobileTools/Simple-Gallery/assets/36371707/d6586139-ee2a-4231-b0cc-03746f1c2005" width=264 />