### PR TITLE
Fixed exception on image resizing (#2883)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ResizeMultipleImagesDialog.kt
@@ -87,7 +87,7 @@ class ResizeMultipleImagesDialog(
                         val lastModified = File(path).lastModified()
 
                         try {
-                            resizeImage(path, size) {
+                            resizeImage(path, path, size) {
                                 if (it) {
                                     pathsToRescan.add(path)
                                     pathLastModifiedMap[path] = lastModified

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/extensions/Activity.kt
@@ -799,7 +799,7 @@ fun BaseSimpleActivity.launchResizeImageDialog(path: String, callback: (() -> Un
             val file = File(newPath)
             val pathLastModifiedMap = mapOf(file.absolutePath to file.lastModified())
             try {
-                resizeImage(newPath, newSize) { success ->
+                resizeImage(path, newPath, newSize) { success ->
                     if (success) {
                         toast(R.string.file_saved)
 
@@ -822,17 +822,17 @@ fun BaseSimpleActivity.launchResizeImageDialog(path: String, callback: (() -> Un
     }
 }
 
-fun BaseSimpleActivity.resizeImage(path: String, size: Point, callback: (success: Boolean) -> Unit) {
+fun BaseSimpleActivity.resizeImage(oldPath: String, newPath: String, size: Point, callback: (success: Boolean) -> Unit) {
     var oldExif: ExifInterface? = null
     if (isNougatPlus()) {
-        val inputStream = contentResolver.openInputStream(Uri.fromFile(File(path)))
+        val inputStream = contentResolver.openInputStream(Uri.fromFile(File(oldPath)))
         oldExif = ExifInterface(inputStream!!)
     }
 
-    val newBitmap = Glide.with(applicationContext).asBitmap().load(path).submit(size.x, size.y).get()
+    val newBitmap = Glide.with(applicationContext).asBitmap().load(oldPath).submit(size.x, size.y).get()
 
-    val newFile = File(path)
-    val newFileDirItem = FileDirItem(path, path.getFilenameFromPath())
+    val newFile = File(newPath)
+    val newFileDirItem = FileDirItem(newPath, newPath.getFilenameFromPath())
     getFileOutputStream(newFileDirItem, true) { out ->
         if (out != null) {
             out.use {


### PR DESCRIPTION
Fixes #2883

Based on the old code from https://github.com/SimpleMobileTools/Simple-Gallery/pull/2851/files#diff-b7924de9715452539ac44202c12732810c03604d47f0e2ccdd8fc63465841533. In case of changed file name, the function was trying to read the bitmap from the new path instead of the old path, so it was needed to send both paths to `resizeImage`.