### PR TITLE
Add separate options for directory grouping

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/MainActivity.kt
@@ -299,7 +299,7 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
     override fun onBackPressed() {
         if (main_menu.isSearchOpen) {
             main_menu.closeSearch()
-        } else if (config.groupDirectSubfolders) {
+        } else if (config.isDirectoryGroupingActive()) {
             if (mCurrentPathPrefix.isEmpty()) {
                 super.onBackPressed()
             } else {
@@ -921,7 +921,7 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
         }
 
         val dirs = getSortedDirectories(newDirs)
-        if (config.groupDirectSubfolders) {
+        if (config.isDirectoryGroupingActive()) {
             mDirs = dirs.clone() as ArrayList<Directory>
         }
 
@@ -1253,7 +1253,7 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
             ) {
                 val clickedDir = it as Directory
                 val path = clickedDir.path
-                if (clickedDir.subfoldersCount == 1 || !config.groupDirectSubfolders) {
+                if (clickedDir.subfoldersCount == 1 || !config.isDirectoryGroupingActive()) {
                     if (path != config.tempFolderPath) {
                         itemClicked(path)
                     }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SettingsActivity.kt
@@ -21,7 +21,7 @@ import kotlinx.android.synthetic.main.activity_settings.*
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
-import java.util.*
+import java.util.Locale
 import kotlin.system.exitProcess
 
 class SettingsActivity : SimpleActivity() {
@@ -892,7 +892,7 @@ class SettingsActivity : SimpleActivity() {
                 put(SORT_ORDER, config.sorting)
                 put(DIRECTORY_SORT_ORDER, config.directorySorting)
                 put(GROUP_BY, config.groupBy)
-                put(GROUP_DIRECT_SUBFOLDERS, config.groupDirectSubfolders)
+                put(DIRECTORY_GROUPING, config.directoryGrouping)
                 put(PINNED_FOLDERS, TextUtils.join(",", config.pinnedFolders))
                 put(DISPLAY_FILE_NAMES, config.displayFileNames)
                 put(FILTER_MEDIA, config.filterMedia)
@@ -987,6 +987,7 @@ class SettingsActivity : SimpleActivity() {
                         checkAppIconColor()
                     }
                 }
+
                 USE_ENGLISH -> config.useEnglish = value.toBoolean()
                 WAS_USE_ENGLISH_TOGGLED -> config.wasUseEnglishToggled = value.toBoolean()
                 WIDGET_BG_COLOR -> config.widgetBgColor = value.toInt()
@@ -1035,7 +1036,7 @@ class SettingsActivity : SimpleActivity() {
                 SORT_ORDER -> config.sorting = value.toInt()
                 DIRECTORY_SORT_ORDER -> config.directorySorting = value.toInt()
                 GROUP_BY -> config.groupBy = value.toInt()
-                GROUP_DIRECT_SUBFOLDERS -> config.groupDirectSubfolders = value.toBoolean()
+                DIRECTORY_GROUPING -> config.directoryGrouping = value.toInt()
                 PINNED_FOLDERS -> config.addPinnedFolders(value.toStringSet())
                 DISPLAY_FILE_NAMES -> config.displayFileNames = value.toBoolean()
                 FILTER_MEDIA -> config.filterMedia = value.toInt()

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SplashActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/activities/SplashActivity.kt
@@ -2,16 +2,21 @@ package com.simplemobiletools.gallery.pro.activities
 
 import android.content.Intent
 import com.simplemobiletools.commons.activities.BaseSplashActivity
+import com.simplemobiletools.commons.extensions.getSharedPrefs
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.gallery.pro.extensions.config
 import com.simplemobiletools.gallery.pro.extensions.favoritesDB
 import com.simplemobiletools.gallery.pro.extensions.getFavoriteFromPath
 import com.simplemobiletools.gallery.pro.extensions.mediaDB
+import com.simplemobiletools.gallery.pro.helpers.DIRECTORY_GROUPING_DIRECT_SUBFOLDERS
+import com.simplemobiletools.gallery.pro.helpers.DIRECTORY_GROUPING_NONE
+import com.simplemobiletools.gallery.pro.helpers.GROUP_DIRECT_SUBFOLDERS
 import com.simplemobiletools.gallery.pro.models.Favorite
 
 class SplashActivity : BaseSplashActivity() {
     override fun initActivity() {
         // check if previously selected favorite items have been properly migrated into the new Favorites table
+        maybeMigrateDirectoryGrouping()
         if (config.wereFavoritesMigrated) {
             launchActivity()
         } else {
@@ -32,6 +37,21 @@ class SplashActivity : BaseSplashActivity() {
                         launchActivity()
                     }
                 }
+            }
+        }
+    }
+
+    private fun maybeMigrateDirectoryGrouping() {
+        if (config.appRunCount == 0) {
+            config.wasDirectoryGroupingMigrated = true
+        } else {
+            if (!config.wasDirectoryGroupingMigrated) {
+                config.directoryGrouping = if (getSharedPrefs().getBoolean(GROUP_DIRECT_SUBFOLDERS, false)) {
+                    DIRECTORY_GROUPING_DIRECT_SUBFOLDERS
+                } else {
+                    DIRECTORY_GROUPING_NONE
+                }
+                config.wasDirectoryGroupingMigrated = true
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/adapters/DirectoryAdapter.kt
@@ -52,7 +52,6 @@ import kotlinx.android.synthetic.main.directory_item_list.view.dir_holder
 import kotlinx.android.synthetic.main.directory_item_list.view.photo_cnt
 import java.io.File
 import java.util.*
-import kotlin.collections.ArrayList
 
 class DirectoryAdapter(
     activity: BaseSimpleActivity, var dirs: ArrayList<Directory>, val listener: DirectoryOperationsListener?, recyclerView: MyRecyclerView,
@@ -66,7 +65,7 @@ class DirectoryAdapter(
     private var scrollHorizontally = config.scrollHorizontally
     private var animateGifs = config.animateGifs
     private var cropThumbnails = config.cropThumbnails
-    private var groupDirectSubfolders = config.groupDirectSubfolders
+    private var isDirectoryGroupingActive = config.isDirectoryGroupingActive()
     private var currentDirectoriesHash = dirs.hashCode()
     private var lockedFolderPaths = ArrayList<String>()
     private var isDragAndDropping = false
@@ -853,7 +852,7 @@ class DirectoryAdapter(
                 nameCount += " (${directory.subfoldersMediaCount})"
             }
 
-            if (groupDirectSubfolders) {
+            if (isDirectoryGroupingActive) {
                 if (directory.subfoldersCount > 1) {
                     nameCount += " [${directory.subfoldersCount}]"
                 }

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ChangeViewTypeDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ChangeViewTypeDialog.kt
@@ -9,6 +9,9 @@ import com.simplemobiletools.commons.helpers.VIEW_TYPE_GRID
 import com.simplemobiletools.commons.helpers.VIEW_TYPE_LIST
 import com.simplemobiletools.gallery.pro.R
 import com.simplemobiletools.gallery.pro.extensions.config
+import com.simplemobiletools.gallery.pro.helpers.DIRECTORY_GROUPING_DIRECT_SUBFOLDERS
+import com.simplemobiletools.gallery.pro.helpers.DIRECTORY_GROUPING_FILE_STRUCTURE
+import com.simplemobiletools.gallery.pro.helpers.DIRECTORY_GROUPING_NONE
 import com.simplemobiletools.gallery.pro.helpers.SHOW_ALL
 import kotlinx.android.synthetic.main.dialog_change_view_type.view.*
 
@@ -35,9 +38,15 @@ class ChangeViewTypeDialog(val activity: BaseSimpleActivity, val fromFoldersView
             }
 
             change_view_type_dialog_radio.check(viewToCheck)
-            change_view_type_dialog_group_direct_subfolders.apply {
+
+            val groupingToCheck = when (config.directoryGrouping) {
+                DIRECTORY_GROUPING_DIRECT_SUBFOLDERS -> grouping_dialog_radio_direct_subfolders.id
+                DIRECTORY_GROUPING_FILE_STRUCTURE -> grouping_dialog_radio_file_structure.id
+                else -> grouping_dialog_radio_none.id
+            }
+            grouping_dialog_radio.apply {
                 beVisibleIf(fromFoldersView)
-                isChecked = config.groupDirectSubfolders
+                check(groupingToCheck)
             }
 
             change_view_type_dialog_use_for_this_folder.apply {
@@ -63,7 +72,11 @@ class ChangeViewTypeDialog(val activity: BaseSimpleActivity, val fromFoldersView
 
         if (fromFoldersView) {
             config.viewTypeFolders = viewType
-            config.groupDirectSubfolders = view.change_view_type_dialog_group_direct_subfolders.isChecked
+            config.directoryGrouping = when (view.grouping_dialog_radio.checkedRadioButtonId) {
+                view.grouping_dialog_radio_direct_subfolders.id -> DIRECTORY_GROUPING_DIRECT_SUBFOLDERS
+                view.grouping_dialog_radio_file_structure.id -> DIRECTORY_GROUPING_FILE_STRUCTURE
+                else -> DIRECTORY_GROUPING_NONE
+            }
         } else {
             if (view.change_view_type_dialog_use_for_this_folder.isChecked) {
                 config.saveFolderViewType(pathToUse, viewType)

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/PickDirectoryDialog.kt
@@ -204,7 +204,7 @@ class PickDirectoryDialog(
         val adapter = DirectoryAdapter(activity, dirs.clone() as ArrayList<Directory>, null, view.directories_grid, true) {
             val clickedDir = it as Directory
             val path = clickedDir.path
-            if (clickedDir.subfoldersCount == 1 || !activity.config.groupDirectSubfolders) {
+            if (clickedDir.subfoldersCount == 1 || !activity.config.isDirectoryGroupingActive()) {
                 if (isPickingCopyMoveDestination && path.trimEnd('/') == sourcePath) {
                     activity.toast(R.string.source_and_destination_same)
                     return@DirectoryAdapter
@@ -236,7 +236,7 @@ class PickDirectoryDialog(
     private fun backPressed() {
         if (searchView.isSearchOpen) {
             searchView.closeSearch()
-        } else if (activity.config.groupDirectSubfolders) {
+        } else if (activity.config.isDirectoryGroupingActive()) {
             if (currentPathPrefix.isEmpty()) {
                 dialog?.dismiss()
             } else {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/helpers/Config.kt
@@ -483,9 +483,17 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getFloat(LAST_EDITOR_CROP_OTHER_ASPECT_RATIO_Y, 1f)
         set(lastEditorCropOtherAspectRatioY) = prefs.edit().putFloat(LAST_EDITOR_CROP_OTHER_ASPECT_RATIO_Y, lastEditorCropOtherAspectRatioY).apply()
 
-    var groupDirectSubfolders: Boolean
-        get() = prefs.getBoolean(GROUP_DIRECT_SUBFOLDERS, false)
-        set(groupDirectSubfolders) = prefs.edit().putBoolean(GROUP_DIRECT_SUBFOLDERS, groupDirectSubfolders).apply()
+    fun isDirectoryGroupingActive(): Boolean {
+        return directoryGrouping != DIRECTORY_GROUPING_NONE
+    }
+
+    var wasDirectoryGroupingMigrated: Boolean
+        get() = prefs.getBoolean(WAS_DIRECTORY_GROUPING_MIGRATED, false)
+        set(wasDirectoryGroupingMigrated) = prefs.edit().putBoolean(WAS_DIRECTORY_GROUPING_MIGRATED, wasDirectoryGroupingMigrated).apply()
+
+    var directoryGrouping: Int
+        get() = prefs.getInt(DIRECTORY_GROUPING, DIRECTORY_GROUPING_NONE)
+        set(directoryGrouping) = prefs.edit().putInt(DIRECTORY_GROUPING, directoryGrouping).apply()
 
     var showWidgetFolderName: Boolean
         get() = prefs.getBoolean(SHOW_WIDGET_FOLDER_NAME, true)

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/helpers/Constants.kt
@@ -78,6 +78,8 @@ const val LAST_EDITOR_CROP_ASPECT_RATIO = "last_editor_crop_aspect_ratio"
 const val LAST_EDITOR_CROP_OTHER_ASPECT_RATIO_X = "last_editor_crop_other_aspect_ratio_x_2"
 const val LAST_EDITOR_CROP_OTHER_ASPECT_RATIO_Y = "last_editor_crop_other_aspect_ratio_y_2"
 const val GROUP_DIRECT_SUBFOLDERS = "group_direct_subfolders"
+const val DIRECTORY_GROUPING = "directory_grouping"
+const val WAS_DIRECTORY_GROUPING_MIGRATED = "was_directory_grouping_migrated"
 const val SHOW_WIDGET_FOLDER_NAME = "show_widget_folder_name"
 const val ALLOW_ONE_TO_ONE_ZOOM = "allow_one_to_one_zoom"
 const val ALLOW_ROTATING_WITH_GESTURES = "allow_rotating_with_gestures"
@@ -152,6 +154,11 @@ const val PICKED_PATHS = "picked_paths"
 const val SHOULD_INIT_FRAGMENT = "should_init_fragment"
 const val PORTRAIT_PATH = "portrait_path"
 const val SKIP_AUTHENTICATION = "skip_authentication"
+
+// directory grouping
+const val DIRECTORY_GROUPING_NONE = 0
+const val DIRECTORY_GROUPING_DIRECT_SUBFOLDERS = 1
+const val DIRECTORY_GROUPING_FILE_STRUCTURE = 2
 
 // rotations
 const val ROTATE_BY_SYSTEM_SETTING = 0

--- a/app/src/main/res/layout/dialog_change_view_type.xml
+++ b/app/src/main/res/layout/dialog_change_view_type.xml
@@ -37,13 +37,31 @@
             android:id="@+id/group_direct_subfolders_divider"
             layout="@layout/divider" />
 
-        <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-            android:id="@+id/change_view_type_dialog_group_direct_subfolders"
+        <RadioGroup
+            android:id="@+id/grouping_dialog_radio"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="@dimen/activity_margin"
-            android:paddingBottom="@dimen/activity_margin"
-            android:text="@string/group_direct_subfolders" />
+            android:layout_marginBottom="@dimen/medium_margin">
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/grouping_dialog_radio_none"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/do_not_group_folders" />
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/grouping_dialog_radio_direct_subfolders"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/group_direct_subfolders" />
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/grouping_dialog_radio_file_structure"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/group_folders_file_structure" />
+
+        </RadioGroup>
 
         <com.simplemobiletools.commons.views.MyAppCompatCheckbox
             android:id="@+id/change_view_type_dialog_use_for_this_folder"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -146,6 +146,8 @@
     <string name="no_media_for_slideshow">لم يتم العثور على أي وسائط لعرض الشرائح</string>
     <!-- View types -->
     <string name="group_direct_subfolders">تجميع المجلدات الفرعية مباشرة</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">تجميع حسب</string>
     <string name="do_not_group_files">عدم تجميع الملفات</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">No media for the slideshow have been found</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -157,6 +157,8 @@
     <string name="no_animation">Няма</string>
     <string name="fade">Знікае</string>
     <string name="group_direct_subfolders">Згрупаваць прамыя падпапкі</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <string name="group_by">Згрупаваць па</string>
     <string name="do_not_group_files">Не групаваць файлы</string>
     <string name="by_folder">Папка</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Не са открити медийни файлове за слайдшоу</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Групиране на вътрешни папки</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Групиране чрез</string>
     <string name="do_not_group_files">Без групиране на файлове</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">স্লাইডশোর জন্য কোন মিডিয়া পাওয়া যায়নি</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">একত্রিত করুন</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">No s\'ha trobat cap contingut multimèdia per a la presentació de diapositives</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Agrupa les subcarpetes directes</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Agrupa per</string>
     <string name="do_not_group_files">No agrupis els fitxers</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -143,6 +143,8 @@
     <string name="no_media_for_slideshow">Nebyla nalezena žádná média pro prezentaci</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Sloučit přímé podsložky</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Seskupit podle</string>
     <string name="do_not_group_files">Neseskupovat</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Der blev ikke fundet nogen mediefiler til lysbilledshowet</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Gruppér direkte undermapper</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Gruppér efter</string>
     <string name="do_not_group_files">Gruppér ikke filer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Keine Medien für Diashow gefunden</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Direkte Unterordner gruppieren</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Gruppieren nach</string>
     <string name="do_not_group_files">Dateien nicht gruppieren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Δεν βρέθηκαν πολυμέσα για την εμφάνιση διαφανειών</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Ομαδοποίηση υποφακέλων</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Ομαδοποίηση κατά</string>
     <string name="do_not_group_files">Χωρίς</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">No media for the slideshow have been found</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -143,6 +143,8 @@
     <string name="no_media_for_slideshow">No se han encontrado medios para la presentación de diapositivas</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Agrupar subcarpetas directas</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Agrupar por</string>
     <string name="do_not_group_files">No agrupar</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Slaidiesitluse jaoks ei ole leitud ühtegi meediafaili</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Rühmita otseseid alamkaustu</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Rühmituse alus</string>
     <string name="do_not_group_files">Ärge rühmita faile</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Diaporamarako multimediarik ez da aurkitu</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Taldekatu zuzeneko azpikarpetak</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Taldekatu</string>
     <string name="do_not_group_files">Ez taldekatu fitxategiak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">No media for the slideshow have been found</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Mediaa diaesitykseen ei löytynyt</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Ryhmitä välittömät alikansiot</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Ryhmitä</string>
     <string name="do_not_group_files">Älä ryhmitä tiedostoja</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -143,6 +143,8 @@
     <string name="no_media_for_slideshow">Aucun média trouvé pour le diaporama</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Mode sous-dossiers</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Grouper par</string>
     <string name="do_not_group_files">Ne pas grouper les fichiers</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Non se atoparon medios para a presentación das diapositivas</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Agrupar subcartafoles directos</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Agrupar por</string>
     <string name="do_not_group_files">Non agrupar ficheiros</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -143,6 +143,8 @@
     <string name="no_media_for_slideshow">Nema datoteka za dijaprojekciju</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Grupiraj izravne podmape</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Grupiraj prema</string>
     <string name="do_not_group_files">Nemoj grupirati ove datoteke</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">A diavetítéshez nem található média</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Közvetlen almappák csoportosítása</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Csoportosítás</string>
     <string name="do_not_group_files">Nincs csoportosítás</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Tidak ditemukan media untuk slideshow</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Kelompokkan subfolder langsung</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Kelompokkan menurut</string>
     <string name="do_not_group_files">Jangan kelompokkan berkas</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -143,6 +143,8 @@
     <string name="no_media_for_slideshow">Nessun file trovato per la presentazione</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Raggruppa sottocartelle dirette</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Raggruppa per</string>
     <string name="do_not_group_files">Non raggruppare i file</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -140,6 +140,8 @@
     <string name="no_media_for_slideshow">לא נמצאה מדיה עבור מצגת השקופיות</string>
     <!-- View types -->
     <string name="group_direct_subfolders">קבץ תיקיות משנה ישירות</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">קבץ לפי</string>
     <string name="do_not_group_files">אין לקבץ קבצים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -140,6 +140,8 @@
     <string name="no_media_for_slideshow">スライドショーに表示するメディアがありません</string>
     <!-- View types -->
     <string name="group_direct_subfolders">サブフォルダでグループ化</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">グループ分け</string>
     <string name="do_not_group_files">何もしない</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">슬라이드 쇼를 표시할 사진이 없습니다.</string>
     <!-- View types -->
     <string name="group_direct_subfolders">상위 폴더 표시</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">그룹 방식</string>
     <string name="do_not_group_files">없음</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -138,6 +138,8 @@
     <string name="no_media_for_slideshow">Nerasta medijos skaidrių demonstracijai</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Ingen media for lysbildeshowet er funnet</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Grupper direkte undermapper</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Grupper etter</string>
     <string name="do_not_group_files">Ikke grupper filer</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">No media for the slideshow have been found</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Geen media gevonden voor diavoorstelling</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Direct onderliggende mappen groeperen</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Groeperen op</string>
     <string name="do_not_group_files">Bestanden niet groeperen</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -140,6 +140,8 @@
     <string name="no_media_for_slideshow">No media for the slideshow have been found</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>
     <string name="do_not_group_files">Do not group files</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -144,6 +144,8 @@
     <string name="no_media_for_slideshow">Nie znaleziono multimediów do pokazu slajdów</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Grupuj bezpośrednie podfoldery</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Grupuj według</string>
     <string name="do_not_group_files">Nie grupuj plików</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Nenhuma mídia encontrada para a apresentação</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Agrupar subpastas diretas</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Agrupar por</string>
     <string name="do_not_group_files">Não agrupar arquivos</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -143,6 +143,8 @@
     <string name="no_media_for_slideshow">Não foram encontrados ficheiros para a apresentação</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Agrupar subpastas</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Agrupar por</string>
     <string name="do_not_group_files">Não agrupar ficheiros</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Nu a fost găsit niciun media pentru slideshow</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Grupează subdosarele directe</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Grupează după</string>
     <string name="do_not_group_files">Nu grupați fișierele</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -144,6 +144,8 @@
     <string name="no_media_for_slideshow">Не найдено медиафайлов для слайдшоу</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Объединять вложенные папки</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Группировать по…</string>
     <string name="do_not_group_files">Не группировать</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Pre prezentáciu sa nenašli žiadne vhodné súbory</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Zlúčiť priame podpriečinky</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Zoskupiť podľa</string>
     <string name="do_not_group_files">Nezoskupovať súbory</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Ne najdem datotek za diaprojekcijo</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Združi neposredne podmape</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Združi po</string>
     <string name="do_not_group_files">Ne združuj datotek</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Нису пронађени медији за слајдшоу</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Групирај директне подфасцикле</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Групиши према</string>
     <string name="do_not_group_files">Не групиши датотеке</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Ingen media hittades för bildspelet</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Gruppera direkta undermappar</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Gruppera efter</string>
     <string name="do_not_group_files">Gruppera inte filer</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">வில்லைக்காட்சிக்கான ஊடகங்கள் ஏதுமில்லை</string>
     <!-- View types -->
     <string name="group_direct_subfolders">நேரடி துணையடைவுகளை ஒன்றிணை</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">இதன்படி ஒன்றிணை</string>
     <string name="do_not_group_files">கோப்புகளை ஒன்றிணைக்காதே</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Slayt gösterisi için medya bulunamadı</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Doğrudan alt klasörleri gruplandır</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Gruplandırma</string>
     <string name="do_not_group_files">Dosyaları gruplandırma</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -144,6 +144,8 @@
     <string name="no_media_for_slideshow">Не знайдено медіафайлів для показу у слайдшоу</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Групувати безпосередні підтеки</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Групувати за</string>
     <string name="do_not_group_files">Не групувати файли</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">Không có tập tin phương tiện cho trình chiếu được tìm thấy</string>
     <!-- View types -->
     <string name="group_direct_subfolders">Nhóm thư mục con trực tiếp</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Nhóm theo</string>
     <string name="do_not_group_files">Không nhóm các tệp</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">没有找到可播放幻灯片媒体文件</string>
     <!-- View types -->
     <string name="group_direct_subfolders">直接分组文件夹</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">分组依据</string>
     <string name="do_not_group_files">不分组文件</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -141,6 +141,8 @@
     <string name="no_media_for_slideshow">找不到投影片的媒體檔案</string>
     <!-- View types -->
     <string name="group_direct_subfolders">歸類子資料夾</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">歸類</string>
     <string name="do_not_group_files">不歸類檔案</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -142,6 +142,8 @@
     <string name="no_media_for_slideshow">找不到投影片的媒體檔案</string>
     <!-- View types -->
     <string name="group_direct_subfolders">歸類子資料夾</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
     <!-- Grouping at media thumbnails -->
     <string name="group_by">歸類</string>
     <string name="do_not_group_files">不歸類檔案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
 
     <!-- View types -->
     <string name="group_direct_subfolders">Group direct subfolders</string>
+    <string name="do_not_group_folders">Do not group folders</string>
+    <string name="group_folders_file_structure">Follow file structure</string>
 
     <!-- Grouping at media thumbnails -->
     <string name="group_by">Group by</string>


### PR DESCRIPTION
Since I can see valid uses for both of these options, I believe it is best to offer both options to the users. File structure grouping will get familiar behavior which will just display directories as they are in the file system, whereas direct subfolder grouping does exactly as it says (groups only direct subfolders - if we were to change it to more than direct, we are moving in the direction of file structure).

This closes #1886