### PR TITLE
fix bug where static webp images will cause high CPU usage

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/PhotoFragment.kt
@@ -435,7 +435,6 @@ class PhotoFragment : ViewPagerFragment() {
             if (drawable.intrinsicWidth == 0) {
                 loadWithGlide(path, addZoomableView)
             } else {
-                drawable.setLoopLimit(0)
                 mView.gestures_view.setImageDrawable(drawable)
             }
         } else {


### PR DESCRIPTION
Regarding issue https://github.com/SimpleMobileTools/Simple-Gallery/issues/2146

The option `setLoopLimit(0)` seems to make the image viewer repeatedly show the frame as fast as possible if the webp has only one frame. Removing the option has no other impact, animated webps are repeated just as expected.