### PR TITLE
close inputstream and datasource to prevent leaks

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/PhotoFragment.kt
@@ -740,18 +740,18 @@ class PhotoFragment : ViewPagerFragment() {
     }
 
     private fun checkIfPanorama() {
-        mIsPanorama = try {
-            val inputStream = if (mMedium.path.startsWith("content:/")) {
+        mIsPanorama = try  {
+            if (mMedium.path.startsWith("content:/")) {
                 requireContext().contentResolver.openInputStream(Uri.parse(mMedium.path))
             } else {
                 File(mMedium.path).inputStream()
+            }.use {
+                val imageParser = JpegImageParser().getXmpXml(ByteSourceInputStream(it, mMedium.name), HashMap<String, Any>())
+                imageParser.contains("GPano:UsePanoramaViewer=\"True\"", true) ||
+                    imageParser.contains("<GPano:UsePanoramaViewer>True</GPano:UsePanoramaViewer>", true) ||
+                    imageParser.contains("GPano:FullPanoWidthPixels=") ||
+                    imageParser.contains("GPano:ProjectionType>Equirectangular")
             }
-
-            val imageParser = JpegImageParser().getXmpXml(ByteSourceInputStream(inputStream, mMedium.name), HashMap<String, Any>())
-            imageParser.contains("GPano:UsePanoramaViewer=\"True\"", true) ||
-                imageParser.contains("<GPano:UsePanoramaViewer>True</GPano:UsePanoramaViewer>", true) ||
-                imageParser.contains("GPano:FullPanoWidthPixels=") ||
-                imageParser.contains("GPano:ProjectionType>Equirectangular")
         } catch (e: Exception) {
             false
         } catch (e: OutOfMemoryError) {

--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/fragments/VideoFragment.kt
@@ -362,6 +362,7 @@ import java.io.FileInputStream
         try {
             fileDataSource.open(dataSpec)
         } catch (e: Exception) {
+            fileDataSource.close()
             activity?.showErrorToast(e)
             return
         }
@@ -369,6 +370,8 @@ import java.io.FileInputStream
         val factory = DataSource.Factory { fileDataSource }
         val mediaSource: MediaSource = ProgressiveMediaSource.Factory(factory)
             .createMediaSource(MediaItem.fromUri(fileDataSource.uri!!))
+
+        fileDataSource.close()
 
         mPlayOnPrepared = true
 


### PR DESCRIPTION
I noticed logcat shows several logs regarding resources not being closed:
```
2023-08-25 13:34:29.860 11220-11233 System                  com.simplemobiletools.gallery.pro    W  A resource failed to call close.
```
So I added this to show stacktraces to unclosed resources to fix them:
```java
        StrictMode.setVmPolicy(VmPolicy.Builder()
            .detectLeakedClosableObjects()
            .penaltyLog()
            .build())
```
I found two occurrences that do not close resources:
* check if a picture should be treated as a panorama
* data source for videos

This PR closes those resources to prevent leaks.