### PR TITLE
Include simple-commons locally using composite build

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ChangeSortingDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/gallery/pro/dialogs/ChangeSortingDialog.kt
@@ -22,7 +22,7 @@ class ChangeSortingDialog(
     init {
         currSorting = if (isDirectorySorting) config.directorySorting else config.getFolderSorting(pathToUse)
         binding = DialogChangeSortingBinding.inflate(activity.layoutInflater).apply {
-            useForThisFolderDivider.beVisibleIf(showFolderCheckbox || (currSorting and SORT_BY_NAME != 0 || currSorting and SORT_BY_PATH != 0))
+            sortingDialogOrderDivider.beVisibleIf(showFolderCheckbox || (currSorting and SORT_BY_NAME != 0 || currSorting and SORT_BY_PATH != 0))
 
             sortingDialogNumericSorting.beVisibleIf(showFolderCheckbox && (currSorting and SORT_BY_NAME != 0 || currSorting and SORT_BY_PATH != 0))
             sortingDialogNumericSorting.isChecked = currSorting and SORT_USE_NUMERIC_VALUE != 0
@@ -46,14 +46,14 @@ class ChangeSortingDialog(
 
     private fun setupSortRadio() {
         val sortingRadio = binding.sortingDialogRadioSorting
-        sortingRadio.setOnCheckedChangeListener { group, checkedId ->
+        sortingRadio.setOnCheckedChangeListener { _, checkedId ->
             val isSortingByNameOrPath = checkedId == binding.sortingDialogRadioName.id || checkedId == binding.sortingDialogRadioPath.id
             binding.sortingDialogNumericSorting.beVisibleIf(isSortingByNameOrPath)
-            binding.useForThisFolderDivider.beVisibleIf(binding.sortingDialogNumericSorting.isVisible() || binding.sortingDialogUseForThisFolder.isVisible())
+            binding.sortingDialogOrderDivider.beVisibleIf(binding.sortingDialogNumericSorting.isVisible() || binding.sortingDialogUseForThisFolder.isVisible())
 
             val hideSortOrder = checkedId == binding.sortingDialogRadioCustom.id || checkedId == binding.sortingDialogRadioRandom.id
             binding.sortingDialogRadioOrder.beGoneIf(hideSortOrder)
-            binding.sortingDialogOrderDivider.beGoneIf(hideSortOrder)
+            binding.sortingDialogSortingDivider.beGoneIf(hideSortOrder)
         }
 
         val sortBtn = when {

--- a/app/src/main/res/layout/dialog_change_sorting.xml
+++ b/app/src/main/res/layout/dialog_change_sorting.xml
@@ -63,9 +63,12 @@
 
         </RadioGroup>
 
-        <include
-            android:id="@+id/sorting_dialog_order_divider"
-            layout="@layout/divider" />
+        <ImageView
+            android:id="@+id/sorting_dialog_sorting_divider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_height"
+            android:background="@color/divider_grey"
+            android:importantForAccessibility="no" />
 
         <RadioGroup
             android:id="@+id/sorting_dialog_radio_order"
@@ -87,9 +90,12 @@
                 android:text="@string/descending" />
         </RadioGroup>
 
-        <include
-            android:id="@+id/use_for_this_folder_divider"
-            layout="@layout/divider" />
+        <ImageView
+            android:id="@+id/sorting_dialog_order_divider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_height"
+            android:background="@color/divider_grey"
+            android:importantForAccessibility="no" />
 
         <com.simplemobiletools.commons.views.MyAppCompatCheckbox
             android:id="@+id/sorting_dialog_numeric_sorting"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 android.enableJetifier=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx8192m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ room = "2.6.0-beta01"
 #Simple tools
 simple-commons = "7c1e5b5777"
 #Gradle
-gradlePlugins-agp = "8.1.0"
+gradlePlugins-agp = "8.1.1"
 #Other
 androidGifDrawable = "1.2.25"
 androidImageCropper = "4.5.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ exif = "1.0.1"
 #Room
 room = "2.6.0-beta01"
 #Simple tools
-simple-commons = "7c1e5b5777"
+simple-commons = "73d78e5cd3"
 #Gradle
 gradlePlugins-agp = "8.1.1"
 #Other

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,12 +17,14 @@ dependencyResolutionManagement {
         maven(url = "https://artifactory.img.ly/artifactory/imgly")
     }
 }
-// TODO: This will be deprecated in future. Migrate to the newer `pluginManagement { includeBuild() }` mechanism instead of explicitly substituting dependency.
-//includeBuild("../Simple-Commons") {
-//    dependencySubstitution {
-//        substitute(module("com.github.SimpleMobileTools:Simple-Commons")).using(project(":commons"))
-//    }
-//}
+
 rootProject.name = "Simple-Gallery"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")
+
+// TODO: This will be deprecated in future. Migrate to the newer `pluginManagement { includeBuild() }` mechanism instead of explicitly substituting dependency.
+/*includeBuild("../Simple-Commons") {
+    dependencySubstitution {
+        substitute(module("com.github.SimpleMobileTools:Simple-Commons")).using(project(":commons"))
+    }
+}*/

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,11 +18,11 @@ dependencyResolutionManagement {
     }
 }
 // TODO: This will be deprecated in future. Migrate to the newer `pluginManagement { includeBuild() }` mechanism instead of explicitly substituting dependency.
-includeBuild("../Simple-Commons") {
-    dependencySubstitution {
-        substitute(module("com.github.SimpleMobileTools:Simple-Commons")).using(project(":commons"))
-    }
-}
+//includeBuild("../Simple-Commons") {
+//    dependencySubstitution {
+//        substitute(module("com.github.SimpleMobileTools:Simple-Commons")).using(project(":commons"))
+//    }
+//}
 rootProject.name = "Simple-Gallery"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,4 +17,12 @@ dependencyResolutionManagement {
         maven(url = "https://artifactory.img.ly/artifactory/imgly")
     }
 }
+// TODO: This will be deprecated in future. Migrate to the newer `pluginManagement { includeBuild() }` mechanism instead of explicitly substituting dependency.
+includeBuild("../Simple-Commons") {
+    dependencySubstitution {
+        substitute(module("com.github.SimpleMobileTools:Simple-Commons")).using(project(":commons"))
+    }
+}
+rootProject.name = "Simple-Gallery"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")


### PR DESCRIPTION
To include the local simple-commons project, simply uncomment the following lines in settings.gradle.kts:
```kotlin
includeBuild("../Simple-Commons") {
    dependencySubstitution {
        substitute(module("com.github.SimpleMobileTools:Simple-Commons")).using(project(":commons"))
    }
}
```
Modify the path to simple-commons project as required. This can be reduced to `includeBuild("../Simple-Commons")` only as mentioned in the TODO but more research is required (might even need to add a new TXT DNS record so we can use commons like `com.simplemobiletools:simple-commons`).

This is cooler than the previous `implementation(project(":commons"))`, it allows you to develop individual projects like simple-commons and simple-gallery [in the same window](https://docs.gradle.org/7.0/userguide/composite_builds.html#composite_build_ide_integration) without any other changes:

<img src="https://github.com/SimpleMobileTools/Simple-Gallery/assets/36371707/e3f692a0-1432-4c20-b3ab-21ea66a569e4" width=600 />

Including commons like this will make testing changes much easier.

**Required changes:**
- Remove duplicated view ids and use in-app dividers if they are accessed programmatically (to avoid binding issues when using commons locally, was racking my brains to fix this one)
- Update AGP to 8.1.1 (composite builds must use the same plugin version)
- Update commons

**Related links:**
 - https://docs.gradle.org/7.0/userguide/composite_builds.html#composite_build_intro
- https://docs.gradle.org/current/userguide/structuring_software_products.html#defining_custom_project_types_as_convention_plugins
- https://docs.gradle.org/current/samples/sample_structuring_software_projects.html
