### PR TITLE
Add avif file support by adding a dependency "com.github.bumptech.glide:avif-integration"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 Simple Gallery brings you all the photo viewing and editing features you have been missing on your Android in one stylish easy-to-use app. Browse, manage, crop and edit photos or videos faster than ever, recover accidentally deleted files or create hidden galleries for your most precious images and videos. And with advanced file-support and full customization, finally, your gallery works just the way you want.
 
-And now it supports AVIF viewing on old Android!
+</br>
+</br>
+
+# **And now it supports AVIF viewing on old Android! Download it at https://github.com/Mario-Hero/Simple-Gallery-AVIF/releases/tag/Publish**
+
+</br>
+</br>
 
 ADVANCED PHOTO EDITOR  
 Turn photo editing into child's play with Simple Gallery's improved file organizer and photo album. Intuitive gestures make it super easy to edit your images on the fly. Crop, flip, rotate and resize pictures or apply stylish filters to make them pop in an instant.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@
 
 Simple Gallery brings you all the photo viewing and editing features you have been missing on your Android in one stylish easy-to-use app. Browse, manage, crop and edit photos or videos faster than ever, recover accidentally deleted files or create hidden galleries for your most precious images and videos. And with advanced file-support and full customization, finally, your gallery works just the way you want.
 
-</br>
-</br>
-
-# **And now it supports AVIF viewing on old Android! Download it at https://github.com/Mario-Hero/Simple-Gallery-AVIF/releases/tag/Publish**
-
-</br>
-</br>
 
 ADVANCED PHOTO EDITOR  
 Turn photo editing into child's play with Simple Gallery's improved file organizer and photo album. Intuitive gestures make it super easy to edit your images on the fly. Crop, flip, rotate and resize pictures or apply stylish filters to make them pop in an instant.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Simple Gallery brings you all the photo viewing and editing features you have been missing on your Android in one stylish easy-to-use app. Browse, manage, crop and edit photos or videos faster than ever, recover accidentally deleted files or create hidden galleries for your most precious images and videos. And with advanced file-support and full customization, finally, your gallery works just the way you want.
 
-
 ADVANCED PHOTO EDITOR  
 Turn photo editing into child's play with Simple Gallery's improved file organizer and photo album. Intuitive gestures make it super easy to edit your images on the fly. Crop, flip, rotate and resize pictures or apply stylish filters to make them pop in an instant.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Simple Gallery brings you all the photo viewing and editing features you have been missing on your Android in one stylish easy-to-use app. Browse, manage, crop and edit photos or videos faster than ever, recover accidentally deleted files or create hidden galleries for your most precious images and videos. And with advanced file-support and full customization, finally, your gallery works just the way you want.
 
+And now it supports AVIF viewing on old Android!
+
 ADVANCED PHOTO EDITOR  
 Turn photo editing into child's play with Simple Gallery's improved file organizer and photo album. Intuitive gestures make it super easy to edit your images on the fly. Crop, flip, rotate and resize pictures or apply stylish filters to make them pop in an instant.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Simple Gallery
+# Simple Gallery AVIF
 
 <img alt="Logo" src="graphics/icon.png" width="120" />
+
+这是Simple Gallery的AVIF改版，使其支持了AVIF图片的读取。可以在右侧的Release页面下载。
+
+This is the AVIF version of Simple Gallery, which now supports the reading of AVIF images. You can download it in Release Page.
+
+</br>
 
 Simple Gallery brings you all the photo viewing and editing features you have been missing on your Android in one stylish easy-to-use app. Browse, manage, crop and edit photos or videos faster than ever, recover accidentally deleted files or create hidden galleries for your most precious images and videos. And with advanced file-support and full customization, finally, your gallery works just the way you want.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("debug")
             if (keystorePropertiesFile.exists()) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -121,6 +122,7 @@ dependencies {
     implementation(libs.picasso) {
         exclude(group = "com.squareup.okhttp3", module = "okhttp")
     }
+    implementation(libs.avif.integration)
     compileOnly(libs.okhttp)
 
     ksp(libs.glide.compiler)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx8192m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,9 @@ room = "2.6.0-beta01"
 #Simple tools
 simple-commons = "9e60e24790"
 #Gradle
-gradlePlugins-agp = "7.4.0"
+gradlePlugins-agp = "8.1.2"
 #Other
-androidGifDrawable = "1.2.25"
+androidGifDrawable = "1.2.28"
 androidImageCropper = "4.5.0"
 apng = "2.28.0"
 awebp = "2.28.0"
@@ -31,7 +31,7 @@ sdkVideowidget = "1.180.0"
 sdkPanowidget = "1.180.0"
 media3Exoplayer = "1.1.0"
 okhttp = "4.9.0"
-okio = "3.0.0"
+okio = "3.6.0"
 picasso = "2.71828"
 #build
 app-build-compileSDKVersion = "34"
@@ -74,6 +74,7 @@ awebp = { module = "com.github.penfeizhou.android.animation:awebp", version.ref 
 glide-compiler = { module = "com.github.bumptech.glide:ksp", version.ref = "glideCompiler" }
 zjupure-webpdecoder = { module = "com.github.zjupure:webpdecoder", version.ref = "zjupureWebpdecoder" }
 picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
+avif-integration = { group = "com.github.bumptech.glide", name = "avif-integration", version = "5.0.0-rc01" }
 [bundles]
 room = [
     "androidx-room-ktx",


### PR DESCRIPTION
This app cannot open avif pictures on old Android(version lower than 12), so I add dependency "com.github.bumptech.glide:avif-integration" to make it support avif. It worked nicely.

After simply adding dependency AVIF, it cannot be built, so I updated gradlePlugins-agp.